### PR TITLE
checking if histogram entry is below 0

### DIFF
--- a/include/laser_filters/intensity_filter.h
+++ b/include/laser_filters/intensity_filter.h
@@ -96,6 +96,8 @@ public:
       int cur_bucket = (int) ((filtered_scan.intensities[i]/hist_max)*num_buckets) ;
       if (cur_bucket >= num_buckets-1)
 	cur_bucket = num_buckets-1 ;
+      if (cur_bucket < 0)
+        cur_bucket = 0;
       histogram[cur_bucket]++ ;
     }
 


### PR DESCRIPTION
If laser scan came in with bogus intensity values (which it does in simulation) this would cause the histogram creation to segfault if trying to increment with an index below 0.

This fixes the segfault, but one could argue it could be fixed differently. Like this, bogus values show up as zeros in the histogram - maybe they should be ignored instead? The histogram seems to be used just for debug purposes anyway.

Ideally, we'd also fix sim so that it does not return bogus intensities.
