### PR TITLE
Fixed typo in exported library names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${EIGEN_INCLUDE_DIRS}
 
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES point_cloud_filters laser_scan_filters
+  LIBRARIES pointcloud_filters laser_scan_filters
   CATKIN_DEPENDS ${THIS_PACKAGE_ROS_DEPS}
   DEPENDS
   )


### PR DESCRIPTION
It's a pretty minor error, but unfortunately breaks the system release due to nonexistent lib_point_cloud_filters.so
