### PR TITLE
missing dependency break isolated build without --install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(laser_filters)
 ##############################################################################
 
 set(THIS_PACKAGE_ROS_DEPS sensor_msgs roscpp tf filters message_filters
-  laser_geometry pluginlib pcl_ros)
+  laser_geometry pluginlib pcl_ros angles)
 
 find_package(catkin REQUIRED COMPONENTS ${THIS_PACKAGE_ROS_DEPS} rostest)
 find_package(Boost REQUIRED COMPONENTS system signals)

--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
   <license>BSD</license>
 
   <url>http://ros.org/wiki/laser_filters</url>
-  
+
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>sensor_msgs</build_depend>
@@ -22,6 +22,7 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>pcl_ros</build_depend>
   <build_depend>rostest</build_depend>
+  <build_depend>angles</build_depend>
 
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
@@ -31,6 +32,7 @@
   <run_depend>laser_geometry</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>pcl_ros</run_depend>
+  <run_depend>angles</run_depend>
 
   <export>
     <cpp cflags="-I${prefix}/include `rosboost-cfg --cflags`" lflags=""/>


### PR DESCRIPTION
`scan_shadows_filter.h` includes `angles/angles.h` without find_package()-ing it. Therefore it fails to find the header in isolated builds without --install.

Experienced it on hydro - did not check groovy.
