### PR TITLE
Don't check the intensities

### DIFF
--- a/include/laser_filters/range_filter.h
+++ b/include/laser_filters/range_filter.h
@@ -74,7 +74,7 @@ public:
   {
     filtered_scan = input_scan;
     for (unsigned int i=0;
-         i < input_scan.ranges.size() && i < input_scan.intensities.size();
+         i < input_scan.ranges.size();
          i++) // Need to check ever reading in the current scan
     {
       {


### PR DESCRIPTION
The intensities are not used in the range filter.
Furthermore, some laser don't have intensities ---e.g hokuyo URG-04LX-UG01---, so this fails for them.
