### PR TITLE
LaserScanAngularRemovalFilter

### DIFF
--- a/include/laser_filters/angular_bounds_filter_in_place.h
+++ b/include/laser_filters/angular_bounds_filter_in_place.h
@@ -34,15 +34,15 @@
 *
 * Author: Kevin Hallenbeck
 *********************************************************************/
-#ifndef LASER_SCAN_ANGULAR_REMOVAL_FILTER_H
-#define LASER_SCAN_ANGULAR_REMOVAL_FILTER_H
+#ifndef LASER_SCAN_ANGULAR_BOUNDS_FILTER_IN_PLACE_H
+#define LASER_SCAN_ANGULAR_BOUNDS_FILTER_IN_PLACE_H
 
 #include <filters/filter_base.h>
 #include <sensor_msgs/LaserScan.h>
 
 namespace laser_filters
 {
-  class LaserScanAngularRemovalFilter : public filters::FilterBase<sensor_msgs::LaserScan>
+  class LaserScanAngularBoundsFilterInPlace : public filters::FilterBase<sensor_msgs::LaserScan>
   {
     public:
       double lower_angle_;
@@ -61,7 +61,7 @@ namespace laser_filters
         return true;
       }
 
-      virtual ~LaserScanAngularRemovalFilter(){}
+      virtual ~LaserScanAngularBoundsFilterInPlace(){}
 
       bool update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& filtered_scan){
         filtered_scan = input_scan; //copy entire message

--- a/include/laser_filters/angular_removal_filter.h
+++ b/include/laser_filters/angular_removal_filter.h
@@ -1,0 +1,90 @@
+/*********************************************************************
+*
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2009, Willow Garage, Inc.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of Willow Garage, Inc. nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*
+* Author: Kevin Hallenbeck
+*********************************************************************/
+#ifndef LASER_SCAN_ANGULAR_REMOVAL_FILTER_H
+#define LASER_SCAN_ANGULAR_REMOVAL_FILTER_H
+
+#include <filters/filter_base.h>
+#include <sensor_msgs/LaserScan.h>
+
+namespace laser_filters
+{
+  class LaserScanAngularRemovalFilter : public filters::FilterBase<sensor_msgs::LaserScan>
+  {
+    public:
+      double lower_angle_;
+      double upper_angle_;
+
+      bool configure()
+      {
+        lower_angle_ = 0;
+        upper_angle_ = 0;
+
+        if(!getParam("lower_angle", lower_angle_) || !getParam("upper_angle", upper_angle_)){
+          ROS_ERROR("Both the lower_angle and upper_angle parameters must be set to use this filter.");
+          return false;
+        }
+
+        return true;
+      }
+
+      virtual ~LaserScanAngularRemovalFilter(){}
+
+      bool update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& filtered_scan){
+        filtered_scan = input_scan; //copy entire message
+
+        double current_angle = input_scan.angle_min;
+        unsigned int count = 0;
+        //loop through the scan and remove ranges at angles between lower_angle_ and upper_angle_
+        for(unsigned int i = 0; i < input_scan.ranges.size(); ++i){
+          if((current_angle > lower_angle_) && (current_angle < upper_angle_)){
+            filtered_scan.ranges[i] = input_scan.range_max + 1.0;
+            if(i < filtered_scan.intensities.size()){
+              filtered_scan.intensities[i] = 0.0;
+            }
+            count++;
+          }
+          current_angle += input_scan.angle_increment;
+        }
+
+        ROS_DEBUG("Filtered out %u points from the laser scan.", count);
+
+        return true;
+
+      }
+  };
+};
+#endif

--- a/laser_filters_plugins.xml
+++ b/laser_filters_plugins.xml
@@ -15,7 +15,7 @@
     <class name="laser_filters/LaserScanRangeFilter" type="laser_filters::LaserScanRangeFilter" 
 	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
-	This is a filter which filters sensor_msgs::LaserScan messages based on intensity
+	This is a filter which filters sensor_msgs::LaserScan messages based on range
       </description>
     </class>
     <class name="laser_filters/ScanShadowsFilter" type="laser_filters::ScanShadowsFilter" 

--- a/laser_filters_plugins.xml
+++ b/laser_filters_plugins.xml
@@ -36,7 +36,7 @@
 	 This is a filter that removes points in a laser scan outside of certain angular bounds.
       </description>
     </class>
-    <class name="laser_filters/LaserScanAngularRemovalFilter" type="laser_filters::LaserScanAngularRemovalFilter" 
+    <class name="laser_filters/LaserScanAngularBoundsFilterInPlace" type="laser_filters::LaserScanAngularBoundsFilterInPlace" 
 	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>
 	 This is a filter that removes points in a laser scan inside of certain angular bounds.

--- a/laser_filters_plugins.xml
+++ b/laser_filters_plugins.xml
@@ -36,6 +36,12 @@
 	 This is a filter that removes points in a laser scan outside of certain angular bounds.
       </description>
     </class>
+    <class name="laser_filters/LaserScanAngularRemovalFilter" type="laser_filters::LaserScanAngularRemovalFilter" 
+	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+      <description>
+	 This is a filter that removes points in a laser scan inside of certain angular bounds.
+      </description>
+    </class>
     <class name="laser_filters/LaserMedianFilter" type="laser_filters::LaserMedianFilter" 
 	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>

--- a/src/laser_scan_filters.cpp
+++ b/src/laser_scan_filters.cpp
@@ -35,7 +35,7 @@
 #include "laser_filters/footprint_filter.h"
 #include "laser_filters/interpolation_filter.h"
 #include "laser_filters/angular_bounds_filter.h"
-#include "laser_filters/angular_removal_filter.h"
+#include "laser_filters/angular_bounds_filter_in_place.h"
 #include "sensor_msgs/LaserScan.h"
 #include "filters/filter_base.h"
 
@@ -47,7 +47,7 @@ PLUGINLIB_DECLARE_CLASS(laser_filters, LaserArrayFilter, laser_filters::LaserArr
 PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanIntensityFilter, laser_filters::LaserScanIntensityFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanRangeFilter, laser_filters::LaserScanRangeFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanAngularBoundsFilter, laser_filters::LaserScanAngularBoundsFilter, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanAngularRemovalFilter, laser_filters::LaserScanAngularRemovalFilter, filters::FilterBase<sensor_msgs::LaserScan>)
+PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanAngularBoundsFilterInPlace, laser_filters::LaserScanAngularBoundsFilterInPlace, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanFootprintFilter, laser_filters::LaserScanFootprintFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_DECLARE_CLASS(laser_filters, ScanShadowsFilter, laser_filters::ScanShadowsFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_DECLARE_CLASS(laser_filters, InterpolationFilter, laser_filters::InterpolationFilter, filters::FilterBase<sensor_msgs::LaserScan>)

--- a/src/laser_scan_filters.cpp
+++ b/src/laser_scan_filters.cpp
@@ -35,6 +35,7 @@
 #include "laser_filters/footprint_filter.h"
 #include "laser_filters/interpolation_filter.h"
 #include "laser_filters/angular_bounds_filter.h"
+#include "laser_filters/angular_removal_filter.h"
 #include "sensor_msgs/LaserScan.h"
 #include "filters/filter_base.h"
 
@@ -46,6 +47,7 @@ PLUGINLIB_DECLARE_CLASS(laser_filters, LaserArrayFilter, laser_filters::LaserArr
 PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanIntensityFilter, laser_filters::LaserScanIntensityFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanRangeFilter, laser_filters::LaserScanRangeFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanAngularBoundsFilter, laser_filters::LaserScanAngularBoundsFilter, filters::FilterBase<sensor_msgs::LaserScan>)
+PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanAngularRemovalFilter, laser_filters::LaserScanAngularRemovalFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanFootprintFilter, laser_filters::LaserScanFootprintFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_DECLARE_CLASS(laser_filters, ScanShadowsFilter, laser_filters::ScanShadowsFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_DECLARE_CLASS(laser_filters, InterpolationFilter, laser_filters::InterpolationFilter, filters::FilterBase<sensor_msgs::LaserScan>)


### PR DESCRIPTION
LaserScanAngularRemovalFilter allows the removal of sections of a LaserScan. I use it to remove pillars on my robot that are visible in the scan, but never move.
