### PR TITLE
add check inf or nan of input laser_scan intensities

### DIFF
--- a/include/laser_filters/intensity_filter.h
+++ b/include/laser_filters/intensity_filter.h
@@ -93,7 +93,9 @@ public:
         filtered_scan.ranges[i] = std::numeric_limits<float>::quiet_NaN();              // If so, then make it an invalid value (NaN)
       }
 
-      int cur_bucket = (int) ((filtered_scan.intensities[i]/hist_max)*num_buckets) ;
+      if( isinf((double)filtered_scan.intensities[i]) || isnan((double)filtered_scan.intensities[i]) )
+	continue;
+      int cur_bucket = (int) ((std::min((double)filtered_scan.intensities[i], hist_max)/hist_max)*num_buckets) ;
       if (cur_bucket >= num_buckets-1)
 	cur_bucket = num_buckets-1 ;
       histogram[cur_bucket]++ ;


### PR DESCRIPTION
When we use `laser_filters/LaserScanIntensityFilter`with gazebo,
this will die because overflowed value is passed to array index around https://github.com/ros-perception/laser_filters/blob/indigo-devel/include/laser_filters/intensity_filter.h#L96-L99

So I added to check the value of intensities and do min compare to prevent overflowed int generating.
