### PR TITLE
scan2scan filter: only publish result if filter succeeded

### DIFF
--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -113,10 +113,8 @@ public:
   void callback(const sensor_msgs::LaserScan::ConstPtr& msg_in)
   {
     // Run the filter chain
-    filter_chain_.update (*msg_in, msg_);
-    
-    // Publish the output
-    output_pub_.publish(msg_);
+    if (filter_chain_.update(*msg_in, msg_));
+      output_pub_.publish(msg_);
   }
 };
 


### PR DESCRIPTION
Without this patch a tf timeout in the footprint filter
will make the module publish the input scan.
