### PR TITLE
Restore cmake_modules build dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>rostest</build_depend>
   <build_depend>angles</build_depend>
+  <build_depend>cmake_modules</build_depend>
 
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>


### PR DESCRIPTION
Was removed in https://github.com/ros-perception/laser_filters/pull/38 , and broke the build on the buildfarm.
