### PR TITLE
Replace the invalid value of scans for the footprint_filter by NaN

### DIFF
--- a/include/laser_filters/footprint_filter.h
+++ b/include/laser_filters/footprint_filter.h
@@ -101,7 +101,7 @@ public:
     {
       if (inFootprint(laser_cloud.points[i])){
         int index = laser_cloud.channels[c_idx].values[i];
-        filtered_scan.ranges[index] = filtered_scan.range_max + 1.0 ; // If so, then make it a value bigger than the max range
+        filtered_scan.ranges[index] = std::numeric_limits<float>::quiet_NaN();
       }
     }
 


### PR DESCRIPTION
The invalid value for scans in the footprint_filter is max_range+1 while the other filters (range_filter, scan_shadows, intensity) use NaN. [REP 117](http://www.ros.org/reps/rep-0117.html) states : "This REP proposes that these values be represented by -Inf, NaN, and +Inf respectively and as defined within floating point standards."
