### PR TITLE
Add LaserScanMaskFilter.

### DIFF
--- a/examples/mask_filter_example.launch
+++ b/examples/mask_filter_example.launch
@@ -1,0 +1,6 @@
+<launch>
+<node pkg="laser_filters" type="scan_to_scan_filter_chain" output="screen" name="laser_filter">
+      <remap from="scan" to="base_scan" />
+      <rosparam command="load" file="$(find laser_filters)/examples/mask_filter_example.yaml" />
+</node>
+</launch>

--- a/examples/mask_filter_example.yaml
+++ b/examples/mask_filter_example.yaml
@@ -1,0 +1,15 @@
+scan_filter_chain:
+- name: mask
+  type: laser_filters/LaserScanMaskFilter
+  params:
+    masks:
+      laser:
+      - 100
+      - 101
+      - 102
+      - 103
+      - 104
+      - 1000
+      - 1001
+      - 1002
+      laser2: []

--- a/include/laser_filters/scan_mask_filter.h
+++ b/include/laser_filters/scan_mask_filter.h
@@ -1,0 +1,130 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+* 
+*  Copyright (c) 2017, laser_filters authors
+*  All rights reserved.
+* 
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+* 
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+* 
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+#ifndef LASER_FILTERS_SCAN_MASK_FILTER_H
+#define LASER_FILTERS_SCAN_MASK_FILTER_H
+/**
+\author Atsushi Watanabe (SEQSENSE, Inc.)
+\brief LaserScanMaskFilter removes points on directions defined in a mask from a laser scan.
+**/
+
+
+#include "filters/filter_base.h"
+#include "sensor_msgs/LaserScan.h"
+
+#include <XmlRpcException.h>
+
+#include <limits>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace laser_filters
+{
+
+class LaserScanMaskFilter : public filters::FilterBase<sensor_msgs::LaserScan>
+{
+public:
+  std::map<std::string, std::vector<size_t> > masks_;
+
+  bool configure()
+  {
+    XmlRpc::XmlRpcValue config;
+    if (!getParam("masks", config))
+    {
+      ROS_ERROR("LaserScanMaskFilter: masks is not defined in the config.");
+      return false;
+    }
+    if (config.getType() == XmlRpc::XmlRpcValue::TypeArray)
+    {
+      ROS_ERROR("LaserScanMaskFilter: masks must be an array of frame_ids with direction list.");
+      return false;
+    }
+    for (XmlRpc::XmlRpcValue::iterator it = config.begin();
+        it != config.end(); ++it)
+    {
+      if (it->second.getType() == XmlRpc::XmlRpcValue::TypeArray)
+      {
+        std::string frame_id = (std::string)(it->first);
+        masks_[frame_id] = std::vector<size_t>();
+        try
+        {
+          for (size_t i = 0; i < it->second.size(); ++i)
+          {
+            size_t id = static_cast<int>(it->second[i]);
+            masks_[frame_id].push_back(id);
+          }
+          ROS_INFO("LaserScanMaskFilter: %s: %d directions will be masked.",
+              frame_id.c_str(), (int)masks_[frame_id].size());
+        }
+        catch(XmlRpc::XmlRpcException &e)
+        {
+          ROS_ERROR("LaserScanMaskFilter: %s", e.getMessage().c_str());
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  virtual ~LaserScanMaskFilter()
+  {
+  }
+
+  bool update(const sensor_msgs::LaserScan& data_in, sensor_msgs::LaserScan& data_out)
+  {
+    data_out = data_in;
+    if (masks_.find(data_out.header.frame_id) == masks_.end())
+    {
+      ROS_WARN("LaserScanMaskFilter: frame_id %s is not registered.",
+          data_out.header.frame_id.c_str());
+      return true;
+    }
+
+    const std::vector<size_t> &mask = masks_[data_out.header.frame_id];
+    const size_t len = data_out.ranges.size();
+    for (std::vector<size_t>::const_iterator it = mask.begin();
+        it != mask.end(); ++it)
+    {
+      if (*it > len) continue;
+      data_out.ranges[*it] = std::numeric_limits<float>::quiet_NaN();
+    }
+
+    return true;
+  }
+};
+
+}  // namespace laser_filters
+
+#endif  // LASER_FILTERS_SCAN_MASK_FILTER_H

--- a/laser_filters_plugins.xml
+++ b/laser_filters_plugins.xml
@@ -48,6 +48,12 @@
 	 This is a filter that removes points in a laser scan inside of a cartesian box.
       </description>
     </class>
+    <class name="laser_filters/LaserScanMaskFilter" type="laser_filters::LaserScanMaskFilter" 
+	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+      <description>
+	 This is a filter that removes points on directions defined in a mask from a laser scan.
+      </description>
+    </class>
     <class name="laser_filters/LaserMedianFilter" type="laser_filters::LaserMedianFilter" 
 	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>

--- a/src/laser_scan_filters.cpp
+++ b/src/laser_scan_filters.cpp
@@ -31,6 +31,7 @@
 #include "laser_filters/array_filter.h"
 #include "laser_filters/intensity_filter.h"
 #include "laser_filters/range_filter.h"
+#include "laser_filters/scan_mask_filter.h"
 #include "laser_filters/scan_shadows_filter.h"
 #include "laser_filters/footprint_filter.h"
 #include "laser_filters/interpolation_filter.h"
@@ -53,3 +54,4 @@ PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanFootprintFilter, laser_filters::
 PLUGINLIB_DECLARE_CLASS(laser_filters, ScanShadowsFilter, laser_filters::ScanShadowsFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_DECLARE_CLASS(laser_filters, InterpolationFilter, laser_filters::InterpolationFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanBoxFilter, laser_filters::LaserScanBoxFilter, filters::FilterBase<sensor_msgs::LaserScan>)
+PLUGINLIB_DECLARE_CLASS(laser_filters, LaserScanMaskFilter, laser_filters::LaserScanMaskFilter, filters::FilterBase<sensor_msgs::LaserScan>)

--- a/test/test_scan_filter_chain.cpp
+++ b/test/test_scan_filter_chain.cpp
@@ -173,6 +173,26 @@ TEST(ScanToScanFilterChain, ArrayFilter)
   filter_chain_.clear();
 }
 
+TEST(ScanToScanFilterChain, MaskFilter)
+{
+  sensor_msgs::LaserScan msg_in, msg_out, expected_msg;
+  const float nanval = std::numeric_limits<float>::quiet_NaN();
+  const float temp[] = {1.0, nanval, 1.0, 1.0, 1.0, nanval, 1.0, 1.0, 1.0, 2.3};
+  const std::vector<float> v1 (temp, temp + sizeof(temp) / sizeof(float));
+  expected_msg.ranges = v1;
+  filters::FilterChain<sensor_msgs::LaserScan> filter_chain_("sensor_msgs::LaserScan");
+
+  EXPECT_TRUE(filter_chain_.configure("mask_filter_chain"));
+
+  msg_in = gen_msg();
+
+  EXPECT_TRUE(filter_chain_.update(msg_in, msg_out));
+
+  expect_ranges_eq(msg_out.ranges, expected_msg.ranges);
+
+  filter_chain_.clear();
+}
+
 
 int main(int argc, char **argv){
   testing::InitGoogleTest(&argc, argv);

--- a/test/test_scan_filter_chain.yaml
+++ b/test/test_scan_filter_chain.yaml
@@ -42,3 +42,11 @@ array_filter_chain:
           params:
             number_of_observations: 3
 
+mask_filter_chain:
+- name: mask
+  type: laser_filters/LaserScanMaskFilter
+  params:
+    masks:
+      laser:
+      - 1
+      - 5


### PR DESCRIPTION
This commit adds LaserScanMaskFilter that removes points on directions defined in a mask, defined as a parameter, from a laser scan.
It can be used to remove unreliable points caused by hardware related problems for example scratches on an optical window of the sensor.