### PR TITLE
Make laser_filters build for ros2 (on windows 10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,55 +1,110 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.5)
 project(laser_filters)
 
 ##############################################################################
 # Find dependencies
 ##############################################################################
 
-set(THIS_PACKAGE_ROS_DEPS sensor_msgs roscpp tf filters message_filters
-  laser_geometry pluginlib angles)
+find_package(ament_cmake REQUIRED)
 
-find_package(catkin REQUIRED COMPONENTS ${THIS_PACKAGE_ROS_DEPS})
-find_package(Boost REQUIRED COMPONENTS system signals)
-include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+find_package(pluginlib REQUIRED)
+find_package(class_loader REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(filters REQUIRED)
+find_package(message_filters REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(laser_geometry REQUIRED)
+find_package(angles REQUIRED)
+find_package(xmlrpcpp REQUIRED)
+find_package(rostime REQUIRED)
 
-##############################################################################
-# Define package
-##############################################################################
+set(Boost_USE_STATIC_LIBS ON)
+find_package(Boost REQUIRED COMPONENTS system signals thread filesystem)
 
-catkin_package(
-  INCLUDE_DIRS include
-  LIBRARIES pointcloud_filters laser_scan_filters
-  CATKIN_DEPENDS ${THIS_PACKAGE_ROS_DEPS}
-  DEPENDS
-  )
+find_package(TinyXML REQUIRED HINTS "*.lib") # add hint seems to allow debug lib to be found when appropriate
+
+include_directories(include 
+  ${pluginlib_INCLUDE_DIRS}
+  ${class_loader_INCLUDE_DIRS}
+  ${sensor_msgs_INCLUDE_DIRS}
+  ${rclcpp_INCLUDE_DIRS}
+  ${tf2_INCLUDE_DIRS}
+  ${filters_INCLUDE_DIRS}
+  ${message_filters_INCLUDE_DIRS}
+  ${tf2_ros_INCLUDE_DIRS}
+  ${laser_geometry_INCLUDE_DIRS}
+  ${angles_INCLUDE_DIRS}
+  ${xmlrpcpp_INCLUDE_DIRS}
+  ${rostime_INCLUDE_DIRS}
+  ${TinyXML_INCLUDE_DIRS}
+  ${Boost_INCLUDE_DIRS}
+)
+
+link_directories(
+  ${pluginlib_LIBRARY_DIRS}
+  ${class_loader_LIBRARY_DIRS}
+  ${sensor_msgs_LIBRARY_DIRS}
+  ${rclcpp_LIBRARY_DIRS}
+  ${tf2_LIBRARY_DIRS}
+  ${filters_LIBRARY_DIRS}
+  ${message_filters_LIBRARY_DIRS}
+  ${tf2_ros_LIBRARY_DIRS}
+  ${laser_geometry_LIBRARY_DIRS}
+  ${angles_LIBRARY_DIRS}
+  ${xmlrpcpp_LIBRARY_DIRS}
+  ${rostime_LIBRARY_DIRS}
+)
+
+add_definitions(-DTRANSFORM_LISTENER_NOT_IMPLEMENTED)
+
+
+set(${PROJECT_NAME}_LIBRARIES 
+  ${pluginlib_LIBRARIES}
+  ${class_loader_LIBRARIES}
+  ${sensor_msgs_LIBRARIES}
+  ${rclcpp_LIBRARIES}
+  ${tf2_LIBRARIES}
+  ${filters_LIBRARIES}
+  ${message_filters_LIBRARIES}
+  ${tf2_ros_LIBRARIES}
+  ${laser_geometry_LIBRARIES}
+  ${angles_LIBRARIES}
+  ${xmlrpcpp_LIBRARIES}
+  ${rostime_LIBRARIES}
+  ${Boost_LIBRARIES}
+)
 
 ##############################################################################
 # Build
 ##############################################################################
 
 add_library(pointcloud_filters src/pointcloud_filters.cpp)
-target_link_libraries(pointcloud_filters ${catkin_LIBRARIES})
+target_link_libraries(pointcloud_filters ${${PROJECT_NAME}_LIBRARIES})
 
 add_library(laser_scan_filters src/laser_scan_filters.cpp src/median_filter.cpp src/array_filter.cpp src/box_filter.cpp)
-target_link_libraries(laser_scan_filters ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(laser_scan_filters ${${PROJECT_NAME}_LIBRARIES})
 
 add_executable(scan_to_cloud_filter_chain src/scan_to_cloud_filter_chain.cpp)
-target_link_libraries(scan_to_cloud_filter_chain ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(scan_to_cloud_filter_chain ${${PROJECT_NAME}_LIBRARIES})
 
 add_executable(scan_to_scan_filter_chain src/scan_to_scan_filter_chain.cpp)
-target_link_libraries(scan_to_scan_filter_chain ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(scan_to_scan_filter_chain ${${PROJECT_NAME}_LIBRARIES})
 
 add_executable(generic_laser_filter_node src/generic_laser_filter_node.cpp)
-target_link_libraries(generic_laser_filter_node ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_link_libraries(generic_laser_filter_node ${${PROJECT_NAME}_LIBRARIES})
 
-if (CATKIN_ENABLE_TESTING)
-  find_package(rostest)
-  add_executable(test_scan_filter_chain test/test_scan_filter_chain.cpp)
-  target_link_libraries(test_scan_filter_chain laser_scan_filters ${rostest_LIBRARIES} gtest)
-  add_dependencies(test_scan_filter_chain gtest)
-
-  add_rostest(test/test_scan_filter_chain.launch)
-endif()
+pluginlib_export_plugin_description_file(laser_filters laser_filters_plugins.xml)
+ament_export_include_directories(include)
+ament_export_libraries(
+  pointcloud_filters 
+  laser_scan_filters 
+  scan_to_cloud_filter_chain
+  scan_to_scan_filter_chain
+  generic_laser_filter_node
+)
+ament_package()
 
 ##############################################################################
 # Install
@@ -59,15 +114,15 @@ install(TARGETS pointcloud_filters laser_scan_filters
   scan_to_cloud_filter_chain
   scan_to_scan_filter_chain
   generic_laser_filter_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
 )
 
 # Install headers
 install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+  DESTINATION include)
 
 install(FILES laser_filters_plugins.xml
-    DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+    DESTINATION share
 )

--- a/include/laser_filters/angular_bounds_filter.h
+++ b/include/laser_filters/angular_bounds_filter.h
@@ -38,11 +38,12 @@
 #define LASER_SCAN_ANGULAR_BOUNDS_FILTER_H
 
 #include <filters/filter_base.h>
-#include <sensor_msgs/LaserScan.h>
+#include <builtin_interfaces/msg/Time.hpp>
+#include <sensor_msgs/msg/Laser_Scan.hpp>
 
 namespace laser_filters
 {
-  class LaserScanAngularBoundsFilter : public filters::FilterBase<sensor_msgs::LaserScan>
+  class LaserScanAngularBoundsFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan>
   {
     public:
       double lower_angle_;
@@ -63,13 +64,13 @@ namespace laser_filters
 
       virtual ~LaserScanAngularBoundsFilter(){}
 
-      bool update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& filtered_scan){
+      bool update(const sensor_msgs::msg::LaserScan& input_scan, sensor_msgs::msg::LaserScan& filtered_scan){
         filtered_scan.ranges.resize(input_scan.ranges.size());
         filtered_scan.intensities.resize(input_scan.intensities.size());
 
         double start_angle = input_scan.angle_min;
         double current_angle = input_scan.angle_min;
-        ros::Time start_time = input_scan.header.stamp;
+        builtin_interfaces::msg::Time start_time = input_scan.header.stamp;
         unsigned int count = 0;
         //loop through the scan and truncate the beginning and the end of the scan as necessary
         for(unsigned int i = 0; i < input_scan.ranges.size(); ++i){
@@ -77,7 +78,7 @@ namespace laser_filters
           if(start_angle < lower_angle_){
             start_angle += input_scan.angle_increment;
             current_angle += input_scan.angle_increment;
-            start_time += ros::Duration(input_scan.time_increment);
+            start_time.set__sec(start_time.sec + input_scan.time_increment);
           }
           else{
             filtered_scan.ranges[count] = input_scan.ranges[i];

--- a/include/laser_filters/angular_bounds_filter_in_place.h
+++ b/include/laser_filters/angular_bounds_filter_in_place.h
@@ -38,11 +38,11 @@
 #define LASER_SCAN_ANGULAR_BOUNDS_FILTER_IN_PLACE_H
 
 #include <filters/filter_base.h>
-#include <sensor_msgs/LaserScan.h>
+#include <sensor_msgs/msg/Laser_Scan.hpp>
 
 namespace laser_filters
 {
-  class LaserScanAngularBoundsFilterInPlace : public filters::FilterBase<sensor_msgs::LaserScan>
+  class LaserScanAngularBoundsFilterInPlace : public filters::FilterBase<sensor_msgs::msg::LaserScan>
   {
     public:
       double lower_angle_;
@@ -63,7 +63,7 @@ namespace laser_filters
 
       virtual ~LaserScanAngularBoundsFilterInPlace(){}
 
-      bool update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& filtered_scan){
+      bool update(const sensor_msgs::msg::LaserScan& input_scan, sensor_msgs::msg::LaserScan& filtered_scan){
         filtered_scan = input_scan; //copy entire message
 
         double current_angle = input_scan.angle_min;

--- a/include/laser_filters/array_filter.h
+++ b/include/laser_filters/array_filter.h
@@ -36,7 +36,11 @@
 
 #include "boost/thread/mutex.hpp"
 #include "boost/scoped_ptr.hpp"
-#include "sensor_msgs/LaserScan.h"
+#include <sensor_msgs/msg/Laser_Scan.hpp>
+
+#ifndef ROS_INFO
+#define ROS_INFO(...)
+#endif // !ROS_INFO
 
 #include "filters/median.h"
 #include "filters/mean.h"
@@ -46,7 +50,7 @@
 namespace laser_filters{
 
 /** \brief A class to provide median filtering of laser scans in time*/
-class LaserArrayFilter : public filters::FilterBase<sensor_msgs::LaserScan> 
+class LaserArrayFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan> 
 {
 public:
   /** \brief Constructor
@@ -61,18 +65,18 @@ public:
    * \param scan_in The new scan to filter
    * \param scan_out The filtered scan
    */
-  bool update(const sensor_msgs::LaserScan& scan_in, sensor_msgs::LaserScan& scan_out);
+  bool update(const sensor_msgs::msg::LaserScan& scan_in, sensor_msgs::msg::LaserScan& scan_out);
 
 
 private:
   unsigned int filter_length_; ///How many scans to average over
   unsigned int num_ranges_; /// How many data point are in each row
 
-  XmlRpc::XmlRpcValue range_config_;
-  XmlRpc::XmlRpcValue intensity_config_;
+  rclcpp::parameter::ParameterVariant range_config_;
+  rclcpp::parameter::ParameterVariant intensity_config_;
 
   boost::mutex data_lock; /// Protection from multi threaded programs
-  sensor_msgs::LaserScan temp_scan_; /** \todo cache only shallow info not full scan */
+  sensor_msgs::msg::LaserScan temp_scan_; /** \todo cache only shallow info not full scan */
   
   filters::MultiChannelFilterChain<float> * range_filter_;
   filters::MultiChannelFilterChain<float> * intensity_filter_;

--- a/include/laser_filters/box_filter.h
+++ b/include/laser_filters/box_filter.h
@@ -49,12 +49,21 @@
 
 #include <filters/filter_base.h>
 
-#include <sensor_msgs/LaserScan.h>
-#include <sensor_msgs/point_cloud_conversion.h>
+#include <tf2/transform_datatypes.h>
+#include <tf2_ros/transform_listener.h>
+#include <sensor_msgs/msg/Laser_Scan.hpp>
+
+typedef tf2::Vector3 Point;
+
+#ifndef ROS_WARN_THROTTLE
+#define ROS_WARN_THROTTLE(...)
+#endif // !ROS_WARN_THROTTLE
+#ifndef ROS_INFO_THROTTLE
+#define ROS_INFO_THROTTLE(...)
+#endif // !ROS_INFO_THROTTLE
+
 #include <laser_geometry/laser_geometry.h>
 
-#include <tf/transform_datatypes.h>
-#include <tf/transform_listener.h>
 
 
 namespace laser_filters
@@ -62,26 +71,27 @@ namespace laser_filters
 /**
  * @brief This is a filter that removes points in a laser scan inside of a cartesian box.
  */
-class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::LaserScan>
+class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan>
 {
   public:
     LaserScanBoxFilter();
     bool configure();
 
     bool update(
-      const sensor_msgs::LaserScan& input_scan,
-      sensor_msgs::LaserScan& filtered_scan);
+      const sensor_msgs::msg::LaserScan& input_scan,
+      sensor_msgs::msg::LaserScan& filtered_scan);
 
   private:
-    bool inBox(tf::Point &point);
+    bool inBox(Point &point);
     std::string box_frame_;
     laser_geometry::LaserProjection projector_;
     
     // tf listener to transform scans into the box_frame
-    tf::TransformListener tf_; 
-    
+    tf2_ros::TransformListener tf_;
+    tf2_ros::Buffer buffer_;
+
     // defines two opposite corners of the box
-    tf::Point min_, max_; 
+    Point min_, max_; 
     bool up_and_running_;
 };
 

--- a/include/laser_filters/intensity_filter.h
+++ b/include/laser_filters/intensity_filter.h
@@ -42,12 +42,13 @@
 
 
 #include "filters/filter_base.h"
-#include "sensor_msgs/LaserScan.h"
+
+#include <sensor_msgs/msg/Laser_Scan.hpp>
 
 namespace laser_filters
 {
 
-class LaserScanIntensityFilter : public filters::FilterBase<sensor_msgs::LaserScan>
+class LaserScanIntensityFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan>
 {
 public:
 
@@ -72,7 +73,7 @@ public:
 
   virtual ~LaserScanIntensityFilter(){}
 
-  bool update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& filtered_scan)
+  bool update(const sensor_msgs::msg::LaserScan& input_scan, sensor_msgs::msg::LaserScan& filtered_scan)
   {
     const double hist_max = 4*12000.0 ;
     const int num_buckets = 24 ;

--- a/include/laser_filters/interpolation_filter.h
+++ b/include/laser_filters/interpolation_filter.h
@@ -42,12 +42,13 @@
 
 
 #include "filters/filter_base.h"
-#include "sensor_msgs/LaserScan.h"
+
+#include <sensor_msgs/msg/Laser_Scan.hpp>
 
 namespace laser_filters
 {
 
-class InterpolationFilter : public filters::FilterBase<sensor_msgs::LaserScan>
+class InterpolationFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan>
 {
 public:
 
@@ -60,7 +61,7 @@ public:
   { 
   }
 
-  bool update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& filtered_scan)
+  bool update(const sensor_msgs::msg::LaserScan& input_scan, sensor_msgs::msg::LaserScan& filtered_scan)
   {
     double previous_valid_range = input_scan.range_max - .01;
     double next_valid_range = input_scan.range_max - .01;

--- a/include/laser_filters/median_filter.h
+++ b/include/laser_filters/median_filter.h
@@ -36,7 +36,12 @@
 
 #include "boost/thread/mutex.hpp"
 #include "boost/scoped_ptr.hpp"
-#include "sensor_msgs/LaserScan.h"
+
+#include <sensor_msgs/msg/Laser_Scan.hpp>
+
+#ifndef ROS_INFO
+#define ROS_INFO(...)
+#endif // !ROS_INFO
 
 #include "filters/median.h"
 #include "filters/mean.h"
@@ -46,7 +51,7 @@
 namespace laser_filters{
 
 /** \brief A class to provide median filtering of laser scans in time*/
-class LaserMedianFilter : public filters::FilterBase<sensor_msgs::LaserScan> 
+class LaserMedianFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan> 
 {
 public:
   /** \brief Constructor
@@ -61,7 +66,7 @@ public:
    * \param scan_in The new scan to filter
    * \param scan_out The filtered scan
    */
-  bool update(const sensor_msgs::LaserScan& scan_in, sensor_msgs::LaserScan& scan_out);
+  bool update(const sensor_msgs::msg::LaserScan& scan_in, sensor_msgs::msg::LaserScan& scan_out);
 
 
 private:
@@ -69,9 +74,9 @@ private:
   unsigned int num_ranges_; /// How many data point are in each row
 
   boost::mutex data_lock; /// Protection from multi threaded programs
-  sensor_msgs::LaserScan temp_scan_; /** \todo cache only shallow info not full scan */
+  sensor_msgs::msg::LaserScan temp_scan_; /** \todo cache only shallow info not full scan */
 
-  XmlRpc::XmlRpcValue xmlrpc_value_;
+  rclcpp::parameter::ParameterVariant parameter_value_;
   
   filters::MultiChannelFilterChain<float> * range_filter_;
   filters::MultiChannelFilterChain<float> * intensity_filter_;

--- a/include/laser_filters/range_filter.h
+++ b/include/laser_filters/range_filter.h
@@ -41,12 +41,12 @@
 
 
 #include "filters/filter_base.h"
-#include "sensor_msgs/LaserScan.h"
+#include <sensor_msgs/msg/Laser_Scan.hpp>
 
 namespace laser_filters
 {
 
-class LaserScanRangeFilter : public filters::FilterBase<sensor_msgs::LaserScan>
+class LaserScanRangeFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan>
 {
 public:
 
@@ -84,7 +84,7 @@ public:
 
   }
 
-  bool update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& filtered_scan)
+  bool update(const sensor_msgs::msg::LaserScan& input_scan, sensor_msgs::msg::LaserScan& filtered_scan)
   {
     if (use_message_range_limits_)
     {

--- a/include/laser_filters/scan_shadows_filter.h
+++ b/include/laser_filters/scan_shadows_filter.h
@@ -40,7 +40,17 @@
 #include <set>
 
 #include "filters/filter_base.h"
-#include <sensor_msgs/LaserScan.h>
+#include <sensor_msgs/msg/Laser_Scan.hpp>
+
+#ifdef _WIN32
+#define _USE_MATH_DEFINES // for C  
+#include <math.h>  
+#endif // _WIN32
+
+#ifndef ROS_INFO
+#define ROS_INFO(...)
+#endif // !ROS_INFO
+
 #include <angles/angles.h>
 
 namespace laser_filters{
@@ -48,7 +58,7 @@ namespace laser_filters{
 /** @b ScanShadowsFilter is a simple filter that filters shadow points in a laser scan line 
  */
 
-class ScanShadowsFilter : public filters::FilterBase<sensor_msgs::LaserScan>
+class ScanShadowsFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan>
 {
 public:
 
@@ -67,23 +77,23 @@ public:
   /**@b Configure the filter from XML */
   bool configure()
   {
-    if (!filters::FilterBase<sensor_msgs::LaserScan>::getParam(std::string("min_angle"), min_angle_))
+    if (!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("min_angle"), min_angle_))
     {
       ROS_ERROR("Error: ShadowsFilter was not given min_angle.\n");
       return false;
     }
-    if (!filters::FilterBase<sensor_msgs::LaserScan>::getParam(std::string("max_angle"), max_angle_))
+    if (!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("max_angle"), max_angle_))
     {
       ROS_ERROR("Error: ShadowsFilter was not given min_angle.\n");
       return false;
     }
-    if (!filters::FilterBase<sensor_msgs::LaserScan>::getParam(std::string("window"), window_))
+    if (!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("window"), window_))
     {
       ROS_ERROR("Error: ShadowsFilter was not given window.\n");
       return false;
     }
     neighbors_ = 0;//default value
-    if (!filters::FilterBase<sensor_msgs::LaserScan>::getParam(std::string("neighbors"), neighbors_))
+    if (!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("neighbors"), neighbors_))
     {
       ROS_INFO("Error: ShadowsFilter was not given neighbors.\n");
     }
@@ -110,7 +120,7 @@ public:
    * \param scan_in the input LaserScan message
    * \param scan_out the output LaserScan message
    */
-  bool update(const sensor_msgs::LaserScan& scan_in, sensor_msgs::LaserScan& scan_out)
+  bool update(const sensor_msgs::msg::LaserScan& scan_in, sensor_msgs::msg::LaserScan& scan_out)
   {
     //copy across all data first
     scan_out = scan_in;

--- a/package.xml
+++ b/package.xml
@@ -1,4 +1,6 @@
-<package>
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
   <name>laser_filters</name>
   <description>
     Assorted filters designed to operate on 2D planar laser scanners,
@@ -11,29 +13,34 @@
 
   <url>http://ros.org/wiki/laser_filters</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
-
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>pluginlib</build_depend>
+  <build_depend>class_loader</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>tf</build_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>tf2</build_depend>
   <build_depend>filters</build_depend>
   <build_depend>message_filters</build_depend>
+  <build_depend>tf2_ros</build_depend>
   <build_depend>laser_geometry</build_depend>
-  <build_depend>pluginlib</build_depend>
-  <build_depend>rostest</build_depend>
   <build_depend>angles</build_depend>
+  <build_depend>xmlrpcpp</build_depend>
+  <build_depend>rostime</build_depend>
 
-  <run_depend>sensor_msgs</run_depend>
-  <run_depend>roscpp</run_depend>
-  <run_depend>tf</run_depend>
-  <run_depend>filters</run_depend>
-  <run_depend>message_filters</run_depend>
-  <run_depend>laser_geometry</run_depend>
-  <run_depend>pluginlib</run_depend>
-  <run_depend>angles</run_depend>
+  <exec_depend>pluginlib</exec_depend>
+  <exec_depend>class_loader</exec_depend>
+  <exec_depend>sensor_msgs</exec_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>tf2</exec_depend>
+  <exec_depend>filters</exec_depend>
+  <exec_depend>message_filters</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>laser_geometry</exec_depend>
+  <exec_depend>angles</exec_depend>
+  <exec_depend>xmlrpcpp</exec_depend>
+  <exec_depend>rostime</exec_depend>
 
   <export>
-    <cpp cflags="-I${prefix}/include `rosboost-cfg --cflags`" lflags=""/>
-    <filters plugin="${prefix}/laser_filters_plugins.xml"/>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/src/array_filter.cpp
+++ b/src/array_filter.cpp
@@ -82,7 +82,7 @@ LaserArrayFilter::~LaserArrayFilter()
     delete intensity_filter_;
 };
 
-bool LaserArrayFilter::update(const sensor_msgs::LaserScan& scan_in, sensor_msgs::LaserScan& scan_out)
+bool LaserArrayFilter::update(const sensor_msgs::msg::LaserScan& scan_in, sensor_msgs::msg::LaserScan& scan_out)
 {
   if (!this->configured_) 
   {

--- a/src/laser_scan_filters.cpp
+++ b/src/laser_scan_filters.cpp
@@ -38,20 +38,21 @@
 #include "laser_filters/angular_bounds_filter.h"
 #include "laser_filters/angular_bounds_filter_in_place.h"
 #include "laser_filters/box_filter.h"
-#include "sensor_msgs/LaserScan.h"
+
+#include <builtin_interfaces/msg/Time.hpp>
+#include <sensor_msgs/msg/Laser_Scan.hpp>
+
 #include "filters/filter_base.h"
+#include <pluginlib/class_list_macros.hpp>  // NOLINT
 
-#include "pluginlib/class_list_macros.h"
-
-
-PLUGINLIB_EXPORT_CLASS(laser_filters::LaserMedianFilter, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_EXPORT_CLASS(laser_filters::LaserArrayFilter, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanIntensityFilter, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanRangeFilter, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanAngularBoundsFilter, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanAngularBoundsFilterInPlace, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanFootprintFilter, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_EXPORT_CLASS(laser_filters::ScanShadowsFilter, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_EXPORT_CLASS(laser_filters::InterpolationFilter, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanBoxFilter, filters::FilterBase<sensor_msgs::LaserScan>)
-PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanMaskFilter, filters::FilterBase<sensor_msgs::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::LaserMedianFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::LaserArrayFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanIntensityFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanRangeFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanAngularBoundsFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanAngularBoundsFilterInPlace, filters::FilterBase<sensor_msgs::msg::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanFootprintFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::ScanShadowsFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::InterpolationFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanBoxFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanMaskFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)

--- a/src/median_filter.cpp
+++ b/src/median_filter.cpp
@@ -33,7 +33,7 @@
 namespace laser_filters
 {
 LaserMedianFilter::LaserMedianFilter() :
-  num_ranges_(1), xmlrpc_value_(), range_filter_(NULL), intensity_filter_(NULL)
+  num_ranges_(1), parameter_value_(), range_filter_(NULL), intensity_filter_(NULL)
 {
     ROS_WARN("LaserMedianFilter has been deprecated.  Please use LaserArrayFilter instead.\n");  
 };
@@ -41,7 +41,7 @@ LaserMedianFilter::LaserMedianFilter() :
 bool LaserMedianFilter::configure()
 {
   
-  if (!getParam("internal_filter", xmlrpc_value_))
+  if (!getParam("internal_filter", parameter_value_))
   {
     ROS_ERROR("Cannot Configure LaserMedianFilter: Didn't find \"internal_filter\" tag within LaserMedianFilter params. Filter definitions needed inside for processing range and intensity");
     return false;
@@ -49,11 +49,11 @@ bool LaserMedianFilter::configure()
   
   if (range_filter_) delete range_filter_;
   range_filter_ = new filters::MultiChannelFilterChain<float>("float");
-  if (!range_filter_->configure(num_ranges_, xmlrpc_value_)) return false;
+  if (!range_filter_->configure(num_ranges_, parameter_value_)) return false;
   
   if (intensity_filter_) delete intensity_filter_;
   intensity_filter_ = new filters::MultiChannelFilterChain<float>("float");
-  if (!intensity_filter_->configure(num_ranges_, xmlrpc_value_)) return false;
+  if (!intensity_filter_->configure(num_ranges_, parameter_value_)) return false;
   return true;
 };
 
@@ -63,7 +63,7 @@ LaserMedianFilter::~LaserMedianFilter()
   delete intensity_filter_;
 };
 
-bool LaserMedianFilter::update(const sensor_msgs::LaserScan& scan_in, sensor_msgs::LaserScan& scan_out)
+bool LaserMedianFilter::update(const sensor_msgs::msg::LaserScan& scan_in, sensor_msgs::msg::LaserScan& scan_out)
 {
   if (!this->configured_) 
   {
@@ -84,10 +84,10 @@ bool LaserMedianFilter::update(const sensor_msgs::LaserScan& scan_in, sensor_msg
     num_ranges_ = scan_in.ranges.size();
     
     range_filter_ = new filters::MultiChannelFilterChain<float>("float");
-    if (!range_filter_->configure(num_ranges_, xmlrpc_value_)) return false;
+    if (!range_filter_->configure(num_ranges_, parameter_value_)) return false;
     
     intensity_filter_ = new filters::MultiChannelFilterChain<float>("float");
-    if (!intensity_filter_->configure(num_ranges_, xmlrpc_value_)) return false;
+    if (!intensity_filter_->configure(num_ranges_, parameter_value_)) return false;
     
   }
 

--- a/src/pointcloud_filters.cpp
+++ b/src/pointcloud_filters.cpp
@@ -27,8 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "sensor_msgs/PointCloud.h"
+#include "sensor_msgs/msg/Point_Cloud.hpp"
 #include "laser_filters/point_cloud_footprint_filter.h"
-#include "pluginlib/class_list_macros.h"
+#include <pluginlib/class_list_macros.hpp>  // NOLINT
 
-PLUGINLIB_EXPORT_CLASS(laser_filters::PointCloudFootprintFilter, filters::FilterBase<sensor_msgs::PointCloud>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::PointCloudFootprintFilter, filters::FilterBase<sensor_msgs::msg::PointCloud>)

--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -34,19 +34,25 @@
 
  */
 
-#include <ros/ros.h>
-#include <sensor_msgs/PointCloud2.h>
-#include <sensor_msgs/LaserScan.h>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/Point_Cloud2.hpp>
+#include <sensor_msgs/msg/Laser_Scan.hpp>
+
+// TF
+#include <tf2_ros/transform_listener.h>
+#include "tf2_ros/message_filter.h"
+
+#include "message_filters/subscriber.h"
+
+//TODO: Fix this
+#define NO_TIMER
+#define ROS_WARN(...)
+
 
 #include <float.h>
 
 // Laser projection
 #include <laser_geometry/laser_geometry.h>
-
-// TF
-#include <tf/transform_listener.h>
-#include "tf/message_filter.h"
-#include "message_filters/subscriber.h"
 
 //Filters
 #include "filters/filter_chain.h"
@@ -67,22 +73,24 @@ public:
   std::string target_frame_;                   // Target frame for high fidelity result
   std::string scan_topic_, cloud_topic_;
 
-  ros::NodeHandle nh;
-  ros::NodeHandle private_nh;
-    
-  // TF
-  tf::TransformListener tf_;
+  rclcpp::Node::SharedPtr nh;
 
-  message_filters::Subscriber<sensor_msgs::LaserScan> sub_;
-  tf::MessageFilter<sensor_msgs::LaserScan> filter_;
+  // TF
+  tf2_ros::TransformListener tf_;
+  tf2_ros::Buffer buffer_;
+
+  message_filters::Subscriber<sensor_msgs::msg::LaserScan> sub_;
+  tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan> filter_;
 
   double tf_tolerance_;
-  filters::FilterChain<sensor_msgs::PointCloud2> cloud_filter_chain_;
-  filters::FilterChain<sensor_msgs::LaserScan> scan_filter_chain_;
-  ros::Publisher cloud_pub_;
+  filters::FilterChain<sensor_msgs::msg::PointCloud2> cloud_filter_chain_;
+  filters::FilterChain<sensor_msgs::msg::LaserScan> scan_filter_chain_;
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr cloud_pub_;
 
   // Timer for displaying deprecation warnings
+#ifndef NO_TIMER
   ros::Timer deprecation_timer_;
+#endif // !NO_TIMER
   bool  using_scan_topic_deprecated_;
   bool  using_cloud_topic_deprecated_;
   bool  using_default_target_frame_deprecated_;
@@ -95,36 +103,44 @@ public:
   bool  incident_angle_correction_;
 
   ////////////////////////////////////////////////////////////////////////////////
-  ScanToCloudFilterChain () : laser_max_range_ (DBL_MAX), private_nh("~"), filter_(tf_, "", 50),
-                   cloud_filter_chain_("sensor_msgs::PointCloud2"), scan_filter_chain_("sensor_msgs::LaserScan")
+  ScanToCloudFilterChain(rclcpp::Node::SharedPtr node) :
+                   nh(node),
+                   laser_max_range_ (DBL_MAX),
+                   sub_(nh, "scan", 50),
+                   tf_(buffer_),
+                   filter_(sub_, buffer_, "", 50),
+                   cloud_filter_chain_("sensor_msgs::msg::PointCloud2"), 
+                   scan_filter_chain_("sensor_msgs::msg::LaserScan")
   {
-    private_nh.param("high_fidelity", high_fidelity_, false);
-    private_nh.param("notifier_tolerance", tf_tolerance_, 0.03);
-    private_nh.param("target_frame", target_frame_, std::string ("base_link"));
+    nh->get_parameter_or("high_fidelity", high_fidelity_, false);
+    nh->get_parameter_or("notifier_tolerance", tf_tolerance_, 0.03);
+    nh->get_parameter_or("target_frame", target_frame_, std::string("base_link"));
+
+    rclcpp::parameter::ParameterVariant variant;
 
     // DEPRECATED with default value
-    using_default_target_frame_deprecated_ = !private_nh.hasParam("target_frame");
+    using_default_target_frame_deprecated_ = !nh->get_parameter("target_frame", variant);
 
     // DEPRECATED
-    using_scan_topic_deprecated_ = private_nh.hasParam("scan_topic");
-    using_cloud_topic_deprecated_ = private_nh.hasParam("cloud_topic");
-    using_laser_max_range_deprecated_ = private_nh.hasParam("laser_max_range");
-    using_filter_window_deprecated_ = private_nh.hasParam("filter_window");
-    using_cloud_filters_deprecated_ = private_nh.hasParam("cloud_filters/filter_chain");
-    using_scan_filters_deprecated_ = private_nh.hasParam("scan_filters/filter_chain");
-    using_cloud_filters_wrong_deprecated_ = private_nh.hasParam("cloud_filters/cloud_filter_chain");
-    using_scan_filters_wrong_deprecated_ = private_nh.hasParam("scan_filters/scan_filter_chain");
+    using_scan_topic_deprecated_ = nh->get_parameter("scan_topic", variant);
+    using_cloud_topic_deprecated_ = nh->get_parameter("cloud_topic", variant);
+    using_laser_max_range_deprecated_ = nh->get_parameter("laser_max_range", variant);
+    using_filter_window_deprecated_ = nh->get_parameter("filter_window", variant);
+    using_cloud_filters_deprecated_ = nh->get_parameter("cloud_filters/filter_chain", variant);
+    using_scan_filters_deprecated_ = nh->get_parameter("scan_filters/filter_chain", variant);
+    using_cloud_filters_wrong_deprecated_ = nh->get_parameter("cloud_filters/cloud_filter_chain", variant);
+    using_scan_filters_wrong_deprecated_ = nh->get_parameter("scan_filters/scan_filter_chain", variant);
 
 
-    private_nh.param("filter_window", window_, 2);
-    private_nh.param("laser_max_range", laser_max_range_, DBL_MAX);
-    private_nh.param("scan_topic", scan_topic_, std::string("tilt_scan"));
-    private_nh.param("cloud_topic", cloud_topic_, std::string("tilt_laser_cloud_filtered"));
-    private_nh.param("incident_angle_correction", incident_angle_correction_, true);
+    nh->get_parameter_or("filter_window", window_, 2);
+    nh->get_parameter_or("laser_max_range", laser_max_range_, DBL_MAX);
+    nh->get_parameter_or("scan_topic", scan_topic_, std::string("tilt_scan"));
+    nh->get_parameter_or("cloud_topic", cloud_topic_, std::string("tilt_laser_cloud_filtered"));
+    nh->get_parameter_or("incident_angle_correction", incident_angle_correction_, true);
 
     filter_.setTargetFrame(target_frame_);
-    filter_.registerCallback(boost::bind(&ScanToCloudFilterChain::scanCallback, this, _1));
-    filter_.setTolerance(ros::Duration(tf_tolerance_));
+    filter_.registerCallback(std::bind(&ScanToCloudFilterChain::scanCallback, this, std::placeholders::_1));
+    filter_.setTolerance(tf2::Duration(ros::Duration(tf_tolerance_).toNSec()));
 
     if (using_scan_topic_deprecated_)
       sub_.subscribe(nh, scan_topic_, 50);
@@ -134,29 +150,32 @@ public:
     filter_.connectInput(sub_);
 
     if (using_cloud_topic_deprecated_)
-      cloud_pub_ = nh.advertise<sensor_msgs::PointCloud2> (cloud_topic_, 10);
+      cloud_pub_ = nh->create_publisher<sensor_msgs::msg::PointCloud2>(cloud_topic_, 10);
     else
-      cloud_pub_ = nh.advertise<sensor_msgs::PointCloud2> ("cloud_filtered", 10);
+      cloud_pub_ = nh->create_publisher<sensor_msgs::msg::PointCloud2>("cloud_filtered", 10);
 
     std::string cloud_filter_xml;
 
     if (using_cloud_filters_deprecated_)
-      cloud_filter_chain_.configure("cloud_filters/filter_chain", private_nh);
+      cloud_filter_chain_.configure("cloud_filters/filter_chain", nh);
     else if (using_cloud_filters_wrong_deprecated_)
-      cloud_filter_chain_.configure("cloud_filters/cloud_filter_chain", private_nh);
+      cloud_filter_chain_.configure("cloud_filters/cloud_filter_chain", nh);
     else
-      cloud_filter_chain_.configure("cloud_filter_chain", private_nh);
+      cloud_filter_chain_.configure("cloud_filter_chain", nh);
 
     if (using_scan_filters_deprecated_)
-      scan_filter_chain_.configure("scan_filter/filter_chain", private_nh);
+      scan_filter_chain_.configure("scan_filter/filter_chain", nh);
     else if (using_scan_filters_wrong_deprecated_)
-      scan_filter_chain_.configure("scan_filters/scan_filter_chain", private_nh);
+      scan_filter_chain_.configure("scan_filters/scan_filter_chain", nh);
     else
-      scan_filter_chain_.configure("scan_filter_chain", private_nh);
+      scan_filter_chain_.configure("scan_filter_chain", nh);
 
+#ifndef NO_TIMER
     deprecation_timer_ = nh.createTimer(ros::Duration(5.0), boost::bind(&ScanToCloudFilterChain::deprecation_warn, this, _1));
+#endif //!NO_TIMER
   }
 
+#ifndef NO_TIMER
   // We use a deprecation warning on a timer to avoid warnings getting lost in the noise
   void deprecation_warn(const ros::TimerEvent& e)
   {
@@ -188,19 +207,19 @@ public:
       ROS_WARN("Use of '~scan_filters/scan_filter_chain' parameter in scan_to_scan_filter_chain is incorrect.  Please Replace with '~scan_filter_chain'");
 
   }
-
+#endif // !NO_TIMER
 
   ////////////////////////////////////////////////////////////////////////////////
   void
-  scanCallback (const sensor_msgs::LaserScan::ConstPtr& scan_msg)
+  scanCallback (const std::shared_ptr<const sensor_msgs::msg::LaserScan>& scan_msg)
   {
-    //    sensor_msgs::LaserScan scan_msg = *scan_in;
+    //    sensor_msgs::msg::LaserScan scan_msg = *scan_in;
 
-    sensor_msgs::LaserScan filtered_scan;
+    sensor_msgs::msg::LaserScan filtered_scan;
     scan_filter_chain_.update (*scan_msg, filtered_scan);
 
     // Project laser into point cloud
-    sensor_msgs::PointCloud2 scan_cloud;
+    sensor_msgs::msg::PointCloud2 scan_cloud;
 
     //\TODO CLEAN UP HACK 
     // This is a trial at correcting for incident angles.  It makes many assumptions that do not generalise
@@ -223,9 +242,9 @@ public:
     {
       try
       {
-        projector_.transformLaserScanToPointCloud (target_frame_, filtered_scan, scan_cloud, tf_, mask);
+        projector_.transformLaserScanToPointCloud(target_frame_, filtered_scan, scan_cloud, buffer_, mask);
       }
-      catch (tf::TransformException &ex)
+      catch (tf2::TransformException &ex)
       {
         ROS_WARN("High fidelity enabled, but TF returned a transform exception to frame %s: %s", target_frame_.c_str (), ex.what ());
         return;
@@ -234,13 +253,13 @@ public:
     }
     else
     {
-      projector_.transformLaserScanToPointCloud(target_frame_, filtered_scan, scan_cloud, tf_, laser_max_range_, mask);
+      projector_.transformLaserScanToPointCloud(target_frame_, filtered_scan, scan_cloud, buffer_, laser_max_range_, mask);
     }
       
-    sensor_msgs::PointCloud2 filtered_cloud;
+    sensor_msgs::msg::PointCloud2 filtered_cloud;
     cloud_filter_chain_.update (scan_cloud, filtered_cloud);
 
-    cloud_pub_.publish(filtered_cloud);
+    cloud_pub_->publish(filtered_cloud);
   }
 
 } ;
@@ -250,11 +269,18 @@ public:
 int
 main (int argc, char** argv)
 {
-  ros::init (argc, argv, "scan_to_cloud_filter_chain");
-  ros::NodeHandle nh;
-  ScanToCloudFilterChain f;
+  ros::Time::init();
+  rclcpp::init(argc, argv);
+  auto nh = rclcpp::Node::make_shared("scan_to_cloud_filter_chain");
+  ScanToCloudFilterChain f(nh);
 
-  ros::spin();
+  rclcpp::WallRate loop_rate(200);
+  while (rclcpp::ok()) {
+
+    rclcpp::spin_some(nh);
+    loop_rate.sleep();
+
+  }
 
   return (0);
 }

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -28,118 +28,141 @@
  */
 
 
-#include "ros/ros.h"
-#include "sensor_msgs/LaserScan.h"
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/Laser_Scan.hpp>
+
+// TF
+#include <tf2_ros/transform_listener.h>
+#include "tf2_ros/message_filter.h"
+
 #include "message_filters/subscriber.h"
-#include "tf/message_filter.h"
-#include "tf/transform_listener.h"
+
+// TODO: fix this
+#define NO_TIMER
+
 #include "filters/filter_chain.h"
 
 class ScanToScanFilterChain
 {
 protected:
   // Our NodeHandle
-  ros::NodeHandle nh_;
-  ros::NodeHandle private_nh_;
+  rclcpp::Node::SharedPtr nh_;
 
   // Components for tf::MessageFilter
-  tf::TransformListener *tf_;
-  message_filters::Subscriber<sensor_msgs::LaserScan> scan_sub_;
-  tf::MessageFilter<sensor_msgs::LaserScan> *tf_filter_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_;
+  tf2_ros::Buffer buffer_;
+
+  message_filters::Subscriber<sensor_msgs::msg::LaserScan> scan_sub_;
+  std::shared_ptr<tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>> tf_filter_;
   double tf_filter_tolerance_;
 
   // Filter Chain
-  filters::FilterChain<sensor_msgs::LaserScan> filter_chain_;
+  filters::FilterChain<sensor_msgs::msg::LaserScan> filter_chain_;
 
   // Components for publishing
-  sensor_msgs::LaserScan msg_;
-  ros::Publisher output_pub_;
+  sensor_msgs::msg::LaserScan msg_;
+  rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr output_pub_;
 
   // Deprecation helpers
+#ifndef NO_TIMER
   ros::Timer deprecation_timer_;
+#endif // !NO_TIMER
   bool  using_filter_chain_deprecated_;
 
 public:
   // Constructor
-  ScanToScanFilterChain() :
-    private_nh_("~"),
+  ScanToScanFilterChain(rclcpp::Node::SharedPtr node) :
+    nh_(node),
     scan_sub_(nh_, "scan", 50),
     tf_(NULL),
     tf_filter_(NULL),
-    filter_chain_("sensor_msgs::LaserScan")
+    filter_chain_("sensor_msgs::msg::LaserScan")
   {
     // Configure filter chain
     
-    using_filter_chain_deprecated_ = private_nh_.hasParam("filter_chain");
+    rclcpp::parameter::ParameterVariant variant;
+    using_filter_chain_deprecated_ = !nh_->get_parameter("filter_chain", variant);
 
     if (using_filter_chain_deprecated_)
-      filter_chain_.configure("filter_chain", private_nh_);
+      filter_chain_.configure("filter_chain", nh_);
     else
-      filter_chain_.configure("scan_filter_chain", private_nh_);
+      filter_chain_.configure("scan_filter_chain", nh_);
     
     std::string tf_message_filter_target_frame;
 
-    if (private_nh_.hasParam("tf_message_filter_target_frame"))
+    if (nh_->get_parameter("tf_message_filter_target_frame", variant))
     {
-      private_nh_.getParam("tf_message_filter_target_frame", tf_message_filter_target_frame);
+      nh_->get_parameter("tf_message_filter_target_frame", tf_message_filter_target_frame);
 
-      private_nh_.param("tf_message_filter_tolerance", tf_filter_tolerance_, 0.03);
+      nh_->get_parameter_or("tf_message_filter_tolerance", tf_filter_tolerance_, 0.03);
 
-      tf_ = new tf::TransformListener();
-      tf_filter_ = new tf::MessageFilter<sensor_msgs::LaserScan>(scan_sub_, *tf_, "", 50);
+      tf_.reset(new tf2_ros::TransformListener(buffer_));
+      tf_filter_.reset(new tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>(scan_sub_, buffer_, "", 50));
       tf_filter_->setTargetFrame(tf_message_filter_target_frame);
-      tf_filter_->setTolerance(ros::Duration(tf_filter_tolerance_));
+      tf_filter_->setTolerance(tf2::Duration(ros::Duration(tf_filter_tolerance_).toNSec()));
 
       // Setup tf::MessageFilter generates callback
-      tf_filter_->registerCallback(boost::bind(&ScanToScanFilterChain::callback, this, _1));
+      tf_filter_->registerCallback(std::bind(&ScanToScanFilterChain::callback, this, std::placeholders::_1));
     }
     else 
     {
       // Pass through if no tf_message_filter_target_frame
-      scan_sub_.registerCallback(boost::bind(&ScanToScanFilterChain::callback, this, _1));
+      scan_sub_.registerCallback(std::bind(&ScanToScanFilterChain::callback, this, std::placeholders::_1));
     }
     
     // Advertise output
-    output_pub_ = nh_.advertise<sensor_msgs::LaserScan>("scan_filtered", 1000);
+    output_pub_ = nh_->create_publisher<sensor_msgs::msg::LaserScan>("scan_filtered", 1000);
 
+#ifndef NO_TIMER
     // Set up deprecation printout
     deprecation_timer_ = nh_.createTimer(ros::Duration(5.0), boost::bind(&ScanToScanFilterChain::deprecation_warn, this, _1));
+#endif // !NO_TIMER
   }
 
   // Destructor
   ~ScanToScanFilterChain()
   {
     if (tf_filter_)
-      delete tf_filter_;
+      tf_filter_.reset();
     if (tf_)
-      delete tf_;
+      tf_.reset();
   }
   
+#ifndef NO_TIMER
   // Deprecation warning callback
   void deprecation_warn(const ros::TimerEvent& e)
   {
     if (using_filter_chain_deprecated_)
       ROS_WARN("Use of '~filter_chain' parameter in scan_to_scan_filter_chain has been deprecated. Please replace with '~scan_filter_chain'.");
   }
+#endif // !NO_TIMER
 
   // Callback
-  void callback(const sensor_msgs::LaserScan::ConstPtr& msg_in)
+  void callback(const std::shared_ptr<const sensor_msgs::msg::LaserScan>& msg_in)
   {
     // Run the filter chain
     if (filter_chain_.update(*msg_in, msg_))
     {
       //only publish result if filter succeeded
-      output_pub_.publish(msg_);
+      output_pub_->publish(msg_);
     }
   }
 };
 
 int main(int argc, char **argv)
 {
-  ros::init(argc, argv, "scan_to_scan_filter_chain");
-  
-  ScanToScanFilterChain t;
-  ros::spin();
-  
+  ros::Time::init();
+  rclcpp::init(argc, argv);
+  auto nh = rclcpp::Node::make_shared("scan_to_scan_filter_chain");
+  ScanToScanFilterChain t(nh);
+
+  rclcpp::WallRate loop_rate(200);
+  while (rclcpp::ok()) {
+
+    rclcpp::spin_some(nh);
+    loop_rate.sleep();
+
+  }
+
   return 0;
 }

--- a/test/test_scan_filter_chain.cpp
+++ b/test/test_scan_filter_chain.cpp
@@ -31,7 +31,7 @@
 #include <filters/filter_chain.h>
 #include <ros/ros.h>
 #include "sensor_msgs/LaserScan.h"
-#include <pluginlib/class_loader.h>
+#include <pluginlib/class_loader.hpp>
 
 
 sensor_msgs::LaserScan gen_msg(){


### PR DESCRIPTION
Should go to a ROS2 branch, but I'm not sure how to create a PR for that :)

Working towards enabling laser_filters in ROS2. This provides ability to build and updates for ROS2 constructs (like Node vs NodeHandle, LaserScan's new namespace).

There are some gaps (TransformListener's waitForTransform, time handling, test code, parameter handling, timers), but it builds and runs.