### PR TITLE
Remove xmlrpcpp (ROS1 conecpt) and add eigen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,6 @@ project(laser_filters)
 find_package(ament_cmake REQUIRED)
 
 find_package(pluginlib REQUIRED)
-find_package(class_loader REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(tf2 REQUIRED)
@@ -22,11 +21,8 @@ find_package(rostime REQUIRED)
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost REQUIRED COMPONENTS system signals thread filesystem)
 
-find_package(TinyXML REQUIRED HINTS "*.lib") # add hint seems to allow debug lib to be found when appropriate
-
 include_directories(include 
   ${pluginlib_INCLUDE_DIRS}
-  ${class_loader_INCLUDE_DIRS}
   ${sensor_msgs_INCLUDE_DIRS}
   ${rclcpp_INCLUDE_DIRS}
   ${tf2_INCLUDE_DIRS}
@@ -36,14 +32,11 @@ include_directories(include
   ${laser_geometry_INCLUDE_DIRS}
   ${angles_INCLUDE_DIRS}
   ${rostime_INCLUDE_DIRS}
-  ${TinyXML_INCLUDE_DIRS}
-  ${EIGEN3_INCLUDE_DIR}
   ${Boost_INCLUDE_DIRS}
 )
 
 link_directories(
   ${pluginlib_LIBRARY_DIRS}
-  ${class_loader_LIBRARY_DIRS}
   ${sensor_msgs_LIBRARY_DIRS}
   ${rclcpp_LIBRARY_DIRS}
   ${tf2_LIBRARY_DIRS}
@@ -60,7 +53,6 @@ add_definitions(-DTRANSFORM_LISTENER_NOT_IMPLEMENTED)
 
 set(${PROJECT_NAME}_LIBRARIES 
   ${pluginlib_LIBRARIES}
-  ${class_loader_LIBRARIES}
   ${sensor_msgs_LIBRARIES}
   ${rclcpp_LIBRARIES}
   ${tf2_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,9 @@ find_package(message_filters REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(laser_geometry REQUIRED)
 find_package(angles REQUIRED)
-find_package(xmlrpcpp REQUIRED)
 find_package(rostime REQUIRED)
+
+find_package(Eigen3 REQUIRED)
 
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost REQUIRED COMPONENTS system signals thread filesystem)
@@ -36,9 +37,9 @@ include_directories(include
   ${tf2_ros_INCLUDE_DIRS}
   ${laser_geometry_INCLUDE_DIRS}
   ${angles_INCLUDE_DIRS}
-  ${xmlrpcpp_INCLUDE_DIRS}
   ${rostime_INCLUDE_DIRS}
   ${TinyXML_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIR}
   ${Boost_INCLUDE_DIRS}
 )
 
@@ -53,7 +54,6 @@ link_directories(
   ${tf2_ros_LIBRARY_DIRS}
   ${laser_geometry_LIBRARY_DIRS}
   ${angles_LIBRARY_DIRS}
-  ${xmlrpcpp_LIBRARY_DIRS}
   ${rostime_LIBRARY_DIRS}
 )
 
@@ -71,7 +71,6 @@ set(${PROJECT_NAME}_LIBRARIES
   ${tf2_ros_LIBRARIES}
   ${laser_geometry_LIBRARIES}
   ${angles_LIBRARIES}
-  ${xmlrpcpp_LIBRARIES}
   ${rostime_LIBRARIES}
   ${Boost_LIBRARIES}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,6 @@ find_package(laser_geometry REQUIRED)
 find_package(angles REQUIRED)
 find_package(rostime REQUIRED)
 
-find_package(Eigen3 REQUIRED)
-
 set(Boost_USE_STATIC_LIBS ON)
 find_package(Boost REQUIRED COMPONENTS system signals thread filesystem)
 

--- a/include/laser_filters/angular_bounds_filter.h
+++ b/include/laser_filters/angular_bounds_filter.h
@@ -39,7 +39,7 @@
 
 #include <filters/filter_base.h>
 #include <builtin_interfaces/msg/Time.hpp>
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 namespace laser_filters
 {

--- a/include/laser_filters/angular_bounds_filter_in_place.h
+++ b/include/laser_filters/angular_bounds_filter_in_place.h
@@ -38,7 +38,7 @@
 #define LASER_SCAN_ANGULAR_BOUNDS_FILTER_IN_PLACE_H
 
 #include <filters/filter_base.h>
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 namespace laser_filters
 {

--- a/include/laser_filters/array_filter.h
+++ b/include/laser_filters/array_filter.h
@@ -36,7 +36,7 @@
 
 #include "boost/thread/mutex.hpp"
 #include "boost/scoped_ptr.hpp"
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 #ifndef ROS_INFO
 #define ROS_INFO(...)

--- a/include/laser_filters/box_filter.h
+++ b/include/laser_filters/box_filter.h
@@ -51,7 +51,7 @@
 
 #include <tf2/transform_datatypes.h>
 #include <tf2_ros/transform_listener.h>
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 typedef tf2::Vector3 Point;
 

--- a/include/laser_filters/footprint_filter.h
+++ b/include/laser_filters/footprint_filter.h
@@ -46,7 +46,7 @@ This is useful for ground plane extraction
 
 #include <tf2/transform_datatypes.h>
 #include <tf2_ros/transform_listener.h>
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 #include <sensor_msgs/msg/Point_Cloud.hpp>
 #include <geometry_msgs/msg/Point32.hpp>
 

--- a/include/laser_filters/intensity_filter.h
+++ b/include/laser_filters/intensity_filter.h
@@ -43,7 +43,7 @@
 
 #include "filters/filter_base.h"
 
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 namespace laser_filters
 {

--- a/include/laser_filters/interpolation_filter.h
+++ b/include/laser_filters/interpolation_filter.h
@@ -43,7 +43,7 @@
 
 #include "filters/filter_base.h"
 
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 namespace laser_filters
 {

--- a/include/laser_filters/median_filter.h
+++ b/include/laser_filters/median_filter.h
@@ -37,7 +37,7 @@
 #include "boost/thread/mutex.hpp"
 #include "boost/scoped_ptr.hpp"
 
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 #ifndef ROS_INFO
 #define ROS_INFO(...)

--- a/include/laser_filters/range_filter.h
+++ b/include/laser_filters/range_filter.h
@@ -41,7 +41,7 @@
 
 
 #include "filters/filter_base.h"
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 namespace laser_filters
 {

--- a/include/laser_filters/scan_mask_filter.h
+++ b/include/laser_filters/scan_mask_filter.h
@@ -42,7 +42,7 @@
 
 #include "filters/filter_base.h"
 
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 #ifndef ROS_INFO
 #define ROS_INFO(...)

--- a/include/laser_filters/scan_shadows_filter.h
+++ b/include/laser_filters/scan_shadows_filter.h
@@ -40,7 +40,7 @@
 #include <set>
 
 #include "filters/filter_base.h"
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 #ifdef _WIN32
 #define _USE_MATH_DEFINES // for C  

--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>pluginlib</build_depend>
-  <build_depend>class_loader</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>tf2</build_depend>
@@ -27,7 +26,6 @@
   <build_depend>rostime</build_depend>
 
   <exec_depend>pluginlib</exec_depend>
-  <exec_depend>class_loader</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>rclcpp</exec_depend>
   <exec_depend>tf2</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,6 @@
   <build_depend>tf2_ros</build_depend>
   <build_depend>laser_geometry</build_depend>
   <build_depend>angles</build_depend>
-  <build_depend>xmlrpcpp</build_depend>
   <build_depend>rostime</build_depend>
 
   <exec_depend>pluginlib</exec_depend>
@@ -37,7 +36,6 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>laser_geometry</exec_depend>
   <exec_depend>angles</exec_depend>
-  <exec_depend>xmlrpcpp</exec_depend>
   <exec_depend>rostime</exec_depend>
 
   <export>

--- a/src/generic_laser_filter_node.cpp
+++ b/src/generic_laser_filter_node.cpp
@@ -29,7 +29,7 @@
 
 
 #include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 // TF
 #include <tf2_ros/transform_listener.h>

--- a/src/laser_scan_filters.cpp
+++ b/src/laser_scan_filters.cpp
@@ -40,7 +40,7 @@
 #include "laser_filters/box_filter.h"
 
 #include <builtin_interfaces/msg/Time.hpp>
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 #include "filters/filter_base.h"
 #include <pluginlib/class_list_macros.hpp>  // NOLINT

--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -36,7 +36,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/Point_Cloud2.hpp>
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 // TF
 #include <tf2_ros/transform_listener.h>

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -29,7 +29,7 @@
 
 
 #include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/Laser_Scan.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
 
 // TF
 #include <tf2_ros/transform_listener.h>


### PR DESCRIPTION
Xmlrpcpp is not needed for the ROS2 parameter concept.

Eigen is needed for laser_geometry header.