### PR TITLE
Reduce computation cost of ScanShadowsFilter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ if (CATKIN_ENABLE_TESTING)
   add_dependencies(test_scan_filter_chain gtest)
 
   add_rostest(test/test_scan_filter_chain.launch)
+
+  catkin_add_gtest(test_shadow_detector test/test_shadow_detector.cpp)
+  target_link_libraries(test_shadow_detector ${catkin_LIBRARIES} ${rostest_LIBRARIES})
 endif()
 
 ##############################################################################

--- a/include/laser_filters/scan_shadow_detector.h
+++ b/include/laser_filters/scan_shadow_detector.h
@@ -1,0 +1,79 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+* 
+*  Copyright (c) 2017, laser_filters authors
+*  All rights reserved.
+* 
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+* 
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+* 
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/*
+\author Atsushi Watanabe (SEQSENSE, Inc.)
+*/
+
+#ifndef SCAN_SHADOW_DETECTOR_H
+#define SCAN_SHADOW_DETECTOR_H
+
+namespace laser_filters
+{
+class ScanShadowDetector
+{
+public:
+  float min_angle_tan_, max_angle_tan_;  // Filter angle threshold
+
+  void configure(const float min_angle, const float max_angle)
+  {
+    min_angle_tan_ = tanf(min_angle);
+    if (min_angle_tan_ < 0.0)
+      min_angle_tan_ = -min_angle_tan_;
+    max_angle_tan_ = tanf(max_angle);
+    if (max_angle_tan_ > 0.0)
+      max_angle_tan_ = -max_angle_tan_;
+  }
+  bool isShadow(const float r1, const float r2, const float included_angle)
+  {
+    const float perpendicular_y_ = r2 * sinf(included_angle);
+    const float perpendicular_x_ = r1 - r2 * cosf(included_angle);
+    const float perpendicular_tan_ = fabs(perpendicular_y_) / perpendicular_x_;
+
+    if (perpendicular_tan_ > 0)
+    {
+      if (perpendicular_tan_ < min_angle_tan_)
+        return true;
+    }
+    else
+    {
+      if (perpendicular_tan_ > max_angle_tan_)
+        return true;
+    }
+    return false;
+  }
+};
+}
+
+#endif  //SCAN_SHADOW_DETECTOR_H

--- a/include/laser_filters/scan_shadow_detector.h
+++ b/include/laser_filters/scan_shadow_detector.h
@@ -44,14 +44,16 @@ namespace laser_filters
 class ScanShadowDetector
 {
 public:
-  float min_angle_tan_, max_angle_tan_;  // Filter angle threshold
+  float min_angle_tan_, max_angle_tan_;  // Filter angle thresholds
 
   void configure(const float min_angle, const float max_angle)
   {
     min_angle_tan_ = tanf(min_angle);
+    max_angle_tan_ = tanf(max_angle);
+
+    // Correct sign of tan around singularity points
     if (min_angle_tan_ < 0.0)
       min_angle_tan_ = -min_angle_tan_;
-    max_angle_tan_ = tanf(max_angle);
     if (max_angle_tan_ > 0.0)
       max_angle_tan_ = -max_angle_tan_;
   }

--- a/include/laser_filters/scan_shadows_filter.h
+++ b/include/laser_filters/scan_shadows_filter.h
@@ -43,25 +43,21 @@
 #include <sensor_msgs/LaserScan.h>
 #include <angles/angles.h>
 
-namespace laser_filters{
-
+namespace laser_filters
+{
 /** @b ScanShadowsFilter is a simple filter that filters shadow points in a laser scan line 
  */
 
 class ScanShadowsFilter : public filters::FilterBase<sensor_msgs::LaserScan>
 {
 public:
-
-  double laser_max_range_;           // Used in laser scan projection
-  double min_angle_, max_angle_;          // Filter angle threshold
+  double laser_max_range_;        // Used in laser scan projection
+  double min_angle_, max_angle_;  // Filter angle threshold
   int window_, neighbors_;
-    
 
   ////////////////////////////////////////////////////////////////////////////////
-  ScanShadowsFilter () 
+  ScanShadowsFilter()
   {
-
-
   }
 
   /**@b Configure the filter from XML */
@@ -82,7 +78,7 @@ public:
       ROS_ERROR("Error: ShadowsFilter was not given window.\n");
       return false;
     }
-    neighbors_ = 0;//default value
+    neighbors_ = 0;  // default value
     if (!filters::FilterBase<sensor_msgs::LaserScan>::getParam(std::string("neighbors"), neighbors_))
     {
       ROS_INFO("Error: ShadowsFilter was not given neighbors.\n");
@@ -92,7 +88,9 @@ public:
   }
 
   ////////////////////////////////////////////////////////////////////////////////
-  virtual ~ScanShadowsFilter () { }
+  virtual ~ScanShadowsFilter()
+  {
+  }
 
   /** @brief calculate the perpendicular angle at the end of r1 to get to r2 
    * See http://en.wikipedia.org/wiki/Law_of_cosines */
@@ -100,7 +98,6 @@ public:
   {
     return atan2(r2 * sin(included_angle), r1 - r2 * cos(included_angle));
   }
-
 
   ////////////////////////////////////////////////////////////////////////////////
   /** \brief Filter shadow points based on 3 global parameters: min_angle, max_angle
@@ -112,44 +109,43 @@ public:
    */
   bool update(const sensor_msgs::LaserScan& scan_in, sensor_msgs::LaserScan& scan_out)
   {
-    //copy across all data first
+    // copy across all data first
     scan_out = scan_in;
 
     std::set<int> indices_to_delete;
     // For each point in the current line scan
-    for (unsigned int i = 0; i < scan_in.ranges.size (); i++)
+    for (unsigned int i = 0; i < scan_in.ranges.size(); i++)
     {
       for (int y = -window_; y < window_ + 1; y++)
       {
         int j = i + y;
-        if ( j < 0 || j >= (int)scan_in.ranges.size () || (int)i == j ){ // Out of scan bounds or itself
+        if (j < 0 || j >= (int)scan_in.ranges.size() || (int)i == j)
+        {  // Out of scan bounds or itself
           continue;
-	}
-
-        double angle = abs(angles::to_degrees(getAngleWithViewpoint (scan_in.ranges[i],scan_in.ranges[j], y * scan_in.angle_increment)));
-        if (angle < min_angle_ || angle > max_angle_) 
-        {
-	  for (int index = std::max<int>(i - neighbors_, 0); index <= std::min<int>(i+neighbors_, (int)scan_in.ranges.size()-1); index++)
-	    {
-	      if (scan_in.ranges[i] < scan_in.ranges[index]) // delete neighbor if they are farther away (note not self)
-		indices_to_delete.insert(index);
-	    }
         }
 
+        double angle = abs(angles::to_degrees(getAngleWithViewpoint(scan_in.ranges[i], scan_in.ranges[j], y * scan_in.angle_increment)));
+        if (angle < min_angle_ || angle > max_angle_)
+        {
+          for (int index = std::max<int>(i - neighbors_, 0); index <= std::min<int>(i + neighbors_, (int)scan_in.ranges.size() - 1); index++)
+          {
+            if (scan_in.ranges[i] < scan_in.ranges[index])  // delete neighbor if they are farther away (note not self)
+              indices_to_delete.insert(index);
+          }
+        }
       }
     }
 
     ROS_DEBUG("ScanShadowsFilter removing %d Points from scan with min angle: %.2f, max angle: %.2f, neighbors: %d, and window: %d", (int)indices_to_delete.size(), min_angle_, max_angle_, neighbors_, window_);
-    for ( std::set<int>::iterator it = indices_to_delete.begin(); it != indices_to_delete.end(); ++it)
-      {
-          scan_out.ranges[*it] = std::numeric_limits<float>::quiet_NaN();  // Failed test to set the ranges to invalid value
-      }
+    for (std::set<int>::iterator it = indices_to_delete.begin(); it != indices_to_delete.end(); ++it)
+    {
+      scan_out.ranges[*it] = std::numeric_limits<float>::quiet_NaN();  // Failed test to set the ranges to invalid value
+    }
     return true;
   }
 
   ////////////////////////////////////////////////////////////////////////////////
-
-} ;
+};
 }
 
-#endif //LASER_SCAN_SHADOWS_FILTER_H
+#endif  // LASER_SCAN_SHADOWS_FILTER_H

--- a/include/laser_filters/scan_shadows_filter.h
+++ b/include/laser_filters/scan_shadows_filter.h
@@ -40,6 +40,7 @@
 #include <set>
 
 #include "filters/filter_base.h"
+#include "laser_filters/scan_shadow_detector.h"
 #include <sensor_msgs/LaserScan.h>
 #include <angles/angles.h>
 
@@ -54,6 +55,8 @@ public:
   double laser_max_range_;        // Used in laser scan projection
   double min_angle_, max_angle_;  // Filter angle threshold
   int window_, neighbors_;
+
+  ScanShadowDetector shadow_detector_;
 
   ////////////////////////////////////////////////////////////////////////////////
   ScanShadowsFilter()
@@ -84,19 +87,36 @@ public:
       ROS_INFO("Error: ShadowsFilter was not given neighbors.\n");
     }
 
+    if (min_angle_ < 0)
+    {
+      ROS_ERROR("min_angle must be 0 <= min_angle. Forcing min_angle = 0.\n");
+      min_angle_ = 0.0;
+    }
+    if (90 < min_angle_)
+    {
+      ROS_ERROR("min_angle must be min_angle <= 90. Forcing min_angle = 90.\n");
+      min_angle_ = 90.0;
+    }
+    if (max_angle_ < 90)
+    {
+      ROS_ERROR("max_angle must be 90 <= max_angle. Forcing max_angle = 90.\n");
+      max_angle_ = 90.0;
+    }
+    if (180 < min_angle_)
+    {
+      ROS_ERROR("max_angle must be max_angle <= 180. Forcing max_angle = 180.\n");
+      max_angle_ = 180.0;
+    }
+    shadow_detector_.configure(
+        angles::from_degrees(min_angle_),
+        angles::from_degrees(max_angle_));
+
     return true;
   }
 
   ////////////////////////////////////////////////////////////////////////////////
   virtual ~ScanShadowsFilter()
   {
-  }
-
-  /** @brief calculate the perpendicular angle at the end of r1 to get to r2 
-   * See http://en.wikipedia.org/wiki/Law_of_cosines */
-  inline double getAngleWithViewpoint(float r1, float r2, float included_angle)
-  {
-    return atan2(r2 * sin(included_angle), r1 - r2 * cos(included_angle));
   }
 
   ////////////////////////////////////////////////////////////////////////////////
@@ -124,19 +144,22 @@ public:
           continue;
         }
 
-        double angle = abs(angles::to_degrees(getAngleWithViewpoint(scan_in.ranges[i], scan_in.ranges[j], y * scan_in.angle_increment)));
-        if (angle < min_angle_ || angle > max_angle_)
+        if (shadow_detector_.isShadow(
+                scan_in.ranges[i], scan_in.ranges[j], y * scan_in.angle_increment))
         {
           for (int index = std::max<int>(i - neighbors_, 0); index <= std::min<int>(i + neighbors_, (int)scan_in.ranges.size() - 1); index++)
           {
-            if (scan_in.ranges[i] < scan_in.ranges[index])  // delete neighbor if they are farther away (note not self)
+            if (scan_in.ranges[i] < scan_in.ranges[index])
+            {  // delete neighbor if they are farther away (note not self)
               indices_to_delete.insert(index);
+            }
           }
         }
       }
     }
 
-    ROS_DEBUG("ScanShadowsFilter removing %d Points from scan with min angle: %.2f, max angle: %.2f, neighbors: %d, and window: %d", (int)indices_to_delete.size(), min_angle_, max_angle_, neighbors_, window_);
+    ROS_DEBUG("ScanShadowsFilter removing %d Points from scan with min angle: %.2f, max angle: %.2f, neighbors: %d, and window: %d",
+              (int)indices_to_delete.size(), min_angle_, max_angle_, neighbors_, window_);
     for (std::set<int>::iterator it = indices_to_delete.begin(); it != indices_to_delete.end(); ++it)
     {
       scan_out.ranges[*it] = std::numeric_limits<float>::quiet_NaN();  // Failed test to set the ranges to invalid value

--- a/test/test_shadow_detector.cpp
+++ b/test/test_shadow_detector.cpp
@@ -70,6 +70,7 @@ TEST(ScanShadowDetector, ShadowDetectionGeometry)
         {
           for (float inc = 0.01; inc < 0.1; inc += 0.02)
           {
+            // Compare with original ScanShadowsFilter implementation
             EXPECT_EQ(
                 detector.isShadow(r1, r2, inc),
                 isShadowPureImpl(r1, r2, inc, min_angle, max_angle));

--- a/test/test_shadow_detector.cpp
+++ b/test/test_shadow_detector.cpp
@@ -1,0 +1,87 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+* 
+*  Copyright (c) 2017, laser_filters authors
+*  All rights reserved.
+* 
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+* 
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+* 
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/*
+\author Atsushi Watanabe (SEQSENSE, Inc.)
+*/
+
+#include <gtest/gtest.h>
+#include <angles/angles.h>
+
+#include "laser_filters/scan_shadow_detector.h"
+
+double getAngleWithViewpoint(const float r1, const float r2, const float included_angle)
+{
+  return atan2(r2 * sin(included_angle), r1 - r2 * cos(included_angle));
+}
+
+bool isShadowPureImpl(const float r1, const float r2, const float included_angle, const double min_angle, const double max_angle)
+{
+  const double angle = fabs(angles::to_degrees(
+      getAngleWithViewpoint(r1, r2, included_angle)));
+  if (angle < min_angle || angle > max_angle)
+    return true;
+  return false;
+}
+
+TEST(ScanShadowDetector, ShadowDetectionGeometry)
+{
+  for (float min_angle = 90.0; min_angle >= 0.0; min_angle -= 5.0)
+  {
+    for (float max_angle = 90.0; max_angle <= 180; max_angle += 5.0)
+    {
+      laser_filters::ScanShadowDetector detector;
+      detector.configure(angles::from_degrees(min_angle), angles::from_degrees(max_angle));
+
+      for (float r1 = 0.1; r1 < 1.0; r1 += 0.1)
+      {
+        for (float r2 = 0.1; r2 < 1.0; r2 += 0.1)
+        {
+          for (float inc = 0.01; inc < 0.1; inc += 0.02)
+          {
+            EXPECT_EQ(
+                detector.isShadow(r1, r2, inc),
+                isShadowPureImpl(r1, r2, inc, min_angle, max_angle));
+          }
+        }
+      }
+    }
+  }
+}
+
+int main(int argc, char **argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
ScanShadowsFilter required a lot of CPU power mainly due to atan2.
This commit reduces computation cost of the filter.

* Remove atan2 and directly compare tangent values
* Add a test to check geometric calculation