### PR TITLE
set values for variables that could be used uninitialized

### DIFF
--- a/src/box_filter.cpp
+++ b/src/box_filter.cpp
@@ -51,7 +51,7 @@ laser_filters::LaserScanBoxFilter::LaserScanBoxFilter(){
 
 bool laser_filters::LaserScanBoxFilter::configure(){
   up_and_running_ = true;
-  double min_x, min_y, min_z, max_x, max_y, max_z;
+  double min_x = 0, min_y = 0, min_z = 0, max_x = 0, max_y = 0, max_z = 0;
   bool box_frame_set = getParam("box_frame", box_frame_);
   bool x_max_set = getParam("max_x", max_x);
   bool y_max_set = getParam("max_y", max_y);


### PR DESCRIPTION
The build fails when enabling the flag **-Werror=maybe-uninitialized**

10:41:15 make[4]: Leaving directory '/tmp/buildd/laser-filters-1.8.5/obj-x86_64-linux-gnu'
10:41:15 [ 64%] Built target pointcloud_filters
10:41:18 In file included from /opt/ros/kinetic/include/tf/LinearMath/Matrix3x3.h:19:0,
10:41:18                  from /opt/ros/kinetic/include/tf/LinearMath/Transform.h:21,
10:41:18                  from /opt/ros/kinetic/include/tf/transform_datatypes.h:41,
10:41:18                  from /opt/ros/kinetic/include/tf/time_cache.h:38,
10:41:18                  from /opt/ros/kinetic/include/tf/tf.h:43,
10:41:18                  from /opt/ros/kinetic/include/laser_geometry/laser_geometry.h:40,
10:41:18                  from /tmp/buildd/laser-filters-1.8.5/include/laser_filters/box_filter.h:54,
10:41:18                  from /tmp/buildd/laser-filters-1.8.5/src/box_filter.cpp:45:
10:41:18 /opt/ros/kinetic/include/tf/LinearMath/Vector3.h: In member function 'virtual bool laser_filters::LaserScanBoxFilter::configure()':
**_10:41:18 
/opt/ros/kinetic/include/tf/LinearMath/Vector3.h:259:61: error: 'min_z' may be used uninitialized in this function [-Werror=maybe-uninitialized]_**
10:41:18    TFSIMD_FORCE_INLINE void setZ(tfScalar z) {m_floats[2] = z;};
10:41:18                                                              ^
10:41:18 /tmp/buildd/laser-filters-1.8.5/src/box_filter.cpp:54:24: note: 'min_z' was declared here
10:41:18    double min_x, min_y, min_z, max_x, max_y, max_z;