### PR TITLE
Fixed naming of laser filter plugins in yaml files

### DIFF
--- a/examples/footprint_filter_example.yaml
+++ b/examples/footprint_filter_example.yaml
@@ -1,5 +1,5 @@
 scan_filter_chain:
 - name: footprint_filter
-  type: LaserScanFootprintFilter
+  type: laser_filters/LaserScanFootprintFilter
   params:
     inscribed_radius: 0.325

--- a/examples/intensity_filter_example.yaml
+++ b/examples/intensity_filter_example.yaml
@@ -1,6 +1,6 @@
 scan_filter_chain:
 - name: intensity
-  type: LaserScanIntensityFilter
+  type: laser_filters/LaserScanIntensityFilter
   params:
     lower_threshold: 8000
     upper_threshold: 100000

--- a/examples/median_filter_5_example.yaml
+++ b/examples/median_filter_5_example.yaml
@@ -1,16 +1,16 @@
 scan_filter_chain:
-- type: LaserArrayFilter
+- type: laser_filters/LaserArrayFilter
   name: laser_median_filter
   params: 
     range_filter_chain:
       - name: median_5
-        type: MultiChannelMedianFilterFloat 
+        type: laser_filters/MultiChannelMedianFilterFloat 
         params:
           number_of_observations: 5
           unused: 10
     intensity_filter_chain:
       - name: median_5
-        type: MultiChannelMedianFilterFloat 
+        type: laser_filters/MultiChannelMedianFilterFloat 
         params:
           number_of_observations: 5
           unused: 10

--- a/examples/multiple_filters_example.yaml
+++ b/examples/multiple_filters_example.yaml
@@ -1,34 +1,34 @@
 scan_filter_chain:
-- type: LaserArrayFilter
+- type: laser_filters/LaserArrayFilter
   name: laser_median_5
   params: 
     range_filter_chain:
       - name: median_5
-        type: MultiChannelMedianFilterFloat 
+        type: laser_filters/MultiChannelMedianFilterFloat 
         params:
           number_of_observations: 5
           unused: 10
     intensity_filter_chain:
       - name: median_5
-        type: MultiChannelMedianFilterFloat 
+        type: laser_filters/MultiChannelMedianFilterFloat 
         params:
           number_of_observations: 5
           unused: 10
 - name: intensity
-  type: LaserScanIntensityFilter
+  type: laser_filters/LaserScanIntensityFilter
   params:
     lower_threshold: 8000
     upper_threshold: 100000
     disp_histogram: 0
 - name: shadows
-  type: ScanShadowsFilter
+  type: laser_filters/ScanShadowsFilter
   params:
     min_angle: 10
     max_angle: 170
     neighbors: 20
     window: 0
 - name: dark_shadows
-  type: LaserScanIntensityFilter
+  type: laser_filters/LaserScanIntensityFilter
   params: 
     lower_threshold: 100
     upper_threshold: 10000

--- a/examples/point_cloud_footprint_filter_example.yaml
+++ b/examples/point_cloud_footprint_filter_example.yaml
@@ -1,5 +1,5 @@
 cloud_filter_chain:
-- type: PointCloudFootprintFilter
+- type: laser_filters/PointCloudFootprintFilter
   name: footprint_filter
   params:
     inscribed_radius: 0.325

--- a/examples/shadow_filter_example.yaml
+++ b/examples/shadow_filter_example.yaml
@@ -1,13 +1,13 @@
 scan_filter_chain:
 - name: shadows
-  type: ScanShadowsFilter
+  type: laser_filters/ScanShadowsFilter
   params:
     min_angle: 10
     max_angle: 170
     neighbors: 20
     window: 1
 - name: dark_shadows
-  type: LaserScanIntensityFilter
+  type: laser_filters/LaserScanIntensityFilter
   params: 
     lower_threshold: 100
     upper_threshold: 10000


### PR DESCRIPTION
This PR solves issue #69.

I just appended the prefix ```laser_filters/``` to all the filter plugins call in this package yaml files.