### PR TITLE
[fix] high_fidelity_ projection now takes laser_max_range_ into account

### DIFF
--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -223,7 +223,7 @@ public:
     {
       try
       {
-        projector_.transformLaserScanToPointCloud (target_frame_, filtered_scan, scan_cloud, tf_, mask);
+        projector_.transformLaserScanToPointCloud(target_frame_, filtered_scan, scan_cloud, tf_, laser_max_range_, mask);
       }
       catch (tf::TransformException &ex)
       {


### PR DESCRIPTION
One line change, tested works.
In my own implementation (ROS Melodic Ubuntu 18) the 30m Hokuyo was somehow cutoff around 20 meters when turning on high_fidelity. This change fixes that.