### PR TITLE
split ROS filter chain from node and add nodelets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project(laser_filters)
 ##############################################################################
 
 set(THIS_PACKAGE_ROS_DEPS sensor_msgs roscpp tf filters message_filters
-  laser_geometry pluginlib angles)
+  laser_geometry pluginlib angles nodelet)
 
 find_package(catkin REQUIRED COMPONENTS ${THIS_PACKAGE_ROS_DEPS})
 find_package(Boost REQUIRED COMPONENTS system)
@@ -30,14 +30,23 @@ catkin_package(
 add_library(pointcloud_filters src/pointcloud_filters.cpp)
 target_link_libraries(pointcloud_filters ${catkin_LIBRARIES})
 
-add_library(laser_scan_filters src/laser_scan_filters.cpp src/median_filter.cpp src/array_filter.cpp src/box_filter.cpp)
+add_library(laser_scan_filters
+  src/laser_scan_filters.cpp
+  src/median_filter.cpp
+  src/array_filter.cpp
+  src/box_filter.cpp
+  src/scan_to_scan_filter_chain.cpp
+  src/scan_to_cloud_filter_chain.cpp
+  src/scan_to_scan_filter_chain_nodelet.cpp
+  src/scan_to_cloud_filter_chain_nodelet.cpp
+)
 target_link_libraries(laser_scan_filters ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
-add_executable(scan_to_cloud_filter_chain src/scan_to_cloud_filter_chain.cpp)
-target_link_libraries(scan_to_cloud_filter_chain ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+add_executable(scan_to_cloud_filter_chain src/scan_to_cloud_filter_chain_node.cpp)
+target_link_libraries(scan_to_cloud_filter_chain laser_scan_filters ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
-add_executable(scan_to_scan_filter_chain src/scan_to_scan_filter_chain.cpp)
-target_link_libraries(scan_to_scan_filter_chain ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+add_executable(scan_to_scan_filter_chain src/scan_to_scan_filter_chain_node.cpp)
+target_link_libraries(scan_to_scan_filter_chain laser_scan_filters ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
 add_executable(generic_laser_filter_node src/generic_laser_filter_node.cpp)
 target_link_libraries(generic_laser_filter_node ${catkin_LIBRARIES} ${Boost_LIBRARIES})
@@ -71,6 +80,6 @@ install(TARGETS pointcloud_filters laser_scan_filters
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
-install(FILES laser_filters_plugins.xml
+install(FILES laser_filters_plugins.xml nodelet_plugins.xml
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )

--- a/include/laser_filters/scan_to_cloud_filter_chain.h
+++ b/include/laser_filters/scan_to_cloud_filter_chain.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2008 Radu Bogdan Rusu <rusu@cs.tum.edu>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $Id: scan_shadows_filter.cpp,v 1.0 2008/12/04 12:00:00 rusu Exp $
+ *
+ */
+
+/*
+\author Radu Bogdan Rusu <rusu@cs.tum.edu>
+
+
+ */
+#ifndef LASER_FILTERS_SCAN_TO_CLOUD_FILTER_CHAIN_H
+#define LASER_FILTERS_SCAN_TO_CLOUD_FILTER_CHAIN_H
+
+#include <ros/ros.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/LaserScan.h>
+
+#include <float.h>
+
+// Laser projection
+#include <laser_geometry/laser_geometry.h>
+
+// TF
+#include <tf/transform_listener.h>
+#include "tf/message_filter.h"
+#include "message_filters/subscriber.h"
+
+//Filters
+#include "filters/filter_chain.h"
+
+namespace laser_filters
+{
+
+/** @b ScanShadowsFilter is a simple class that filters shadow points in a laser scan line and publishes the results in a cloud.
+ */
+class ScanToCloudFilterChain
+{
+public:
+  ScanToCloudFilterChain (const ros::NodeHandle& nh, const ros::NodeHandle& pnh);
+
+protected:
+
+  // ROS related
+  laser_geometry::LaserProjection projector_; // Used to project laser scans
+
+  double laser_max_range_;           // Used in laser scan projection
+  int window_;
+    
+  bool high_fidelity_;                    // High fidelity (interpolating time across scan)
+  std::string target_frame_;                   // Target frame for high fidelity result
+  std::string scan_topic_, cloud_topic_;
+
+  ros::NodeHandle nh_;
+  ros::NodeHandle private_nh_;
+    
+  // TF
+  tf::TransformListener tf_;
+
+  message_filters::Subscriber<sensor_msgs::LaserScan> sub_;
+  tf::MessageFilter<sensor_msgs::LaserScan> filter_;
+
+  double tf_tolerance_;
+  filters::FilterChain<sensor_msgs::PointCloud2> cloud_filter_chain_;
+  filters::FilterChain<sensor_msgs::LaserScan> scan_filter_chain_;
+  ros::Publisher cloud_pub_;
+
+  // Timer for displaying deprecation warnings
+  ros::Timer deprecation_timer_;
+  bool  using_scan_topic_deprecated_;
+  bool  using_cloud_topic_deprecated_;
+  bool  using_default_target_frame_deprecated_;
+  bool  using_laser_max_range_deprecated_;
+  bool  using_filter_window_deprecated_;
+  bool  using_scan_filters_deprecated_;
+  bool  using_cloud_filters_deprecated_;
+  bool  using_scan_filters_wrong_deprecated_;
+  bool  using_cloud_filters_wrong_deprecated_;
+  bool  incident_angle_correction_;
+
+  // We use a deprecation warning on a timer to avoid warnings getting lost in the noise
+  void deprecation_warn(const ros::TimerEvent& e);
+  
+  ////////////////////////////////////////////////////////////////////////////////
+  void scanCallback (const sensor_msgs::LaserScan::ConstPtr& scan_msg);
+};
+
+}  // namespace laser_filters
+
+#endif  // LASER_FILTERS_SCAN_TO_CLOUD_FILTER_CHAIN_H

--- a/include/laser_filters/scan_to_scan_filter_chain.h
+++ b/include/laser_filters/scan_to_scan_filter_chain.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef LASER_FILTERS_SCAN_TO_SCAN_FILTER_CHAIN_H
+#define LASER_FILTERS_SCAN_TO_SCAN_FILTER_CHAIN_H
+
+#include "ros/ros.h"
+#include "sensor_msgs/LaserScan.h"
+#include "message_filters/subscriber.h"
+#include "tf/message_filter.h"
+#include "tf/transform_listener.h"
+#include "filters/filter_chain.h"
+
+namespace laser_filters
+{
+
+class ScanToScanFilterChain
+{
+public:
+  ScanToScanFilterChain(const ros::NodeHandle& nh, const ros::NodeHandle& pnh);
+
+  ~ScanToScanFilterChain();
+
+protected:
+  // Our NodeHandle
+  ros::NodeHandle nh_;
+  ros::NodeHandle private_nh_;
+
+  // Components for tf::MessageFilter
+  tf::TransformListener *tf_;
+  message_filters::Subscriber<sensor_msgs::LaserScan> scan_sub_;
+  tf::MessageFilter<sensor_msgs::LaserScan> *tf_filter_;
+  double tf_filter_tolerance_;
+
+  // Filter Chain
+  filters::FilterChain<sensor_msgs::LaserScan> filter_chain_;
+
+  // Components for publishing
+  sensor_msgs::LaserScan msg_;
+  ros::Publisher output_pub_;
+
+  // Deprecation helpers
+  ros::Timer deprecation_timer_;
+  bool  using_filter_chain_deprecated_;
+
+  // Deprecation warning callback
+  void deprecation_warn(const ros::TimerEvent& e);
+
+  // Callback
+  void callback(const sensor_msgs::LaserScan::ConstPtr& msg_in);
+};
+
+}  // namespace laser_filters
+
+#endif  // LASER_FILTERS_SCAN_TO_SCAN_FILTER_CHAIN_H

--- a/nodelet_plugins.xml
+++ b/nodelet_plugins.xml
@@ -1,0 +1,12 @@
+<library path="lib/liblaser_scan_filters">
+  <class name="laser_filters/ScanToScanFilterChainNodelet" type="laser_filters::ScanToScanFilterChainNodelet" base_class_type="nodelet::Nodelet">
+    <description>
+      Nodelet to run a laser scan to laser scan filter chain.
+    </description>
+  </class>
+  <class name="laser_filters/ScanToCloudFilterChainNodelet" type="laser_filters::ScanToCloudFilterChainNodelet" base_class_type="nodelet::Nodelet">
+    <description>
+      Nodelet to run a laser scan to point cloud filter chain.
+    </description>
+  </class>
+</library>

--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,7 @@
   <build_depend>pluginlib</build_depend>
   <build_depend>rostest</build_depend>
   <build_depend>angles</build_depend>
+  <build_depend>nodelet</build_depend>
 
   <run_depend>sensor_msgs</run_depend>
   <run_depend>roscpp</run_depend>
@@ -31,9 +32,11 @@
   <run_depend>laser_geometry</run_depend>
   <run_depend>pluginlib</run_depend>
   <run_depend>angles</run_depend>
+  <run_depend>nodelet</run_depend>
 
   <export>
     <cpp cflags="-I${prefix}/include `rosboost-cfg --cflags`" lflags=""/>
     <filters plugin="${prefix}/laser_filters_plugins.xml"/>
+    <nodelet plugin="${prefix}/nodelet_plugins.xml"/>
   </export>
 </package>

--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -30,233 +30,158 @@
 
 /*
 \author Radu Bogdan Rusu <rusu@cs.tum.edu>
-
-
  */
+#include "laser_filters/scan_to_cloud_filter_chain.h"
 
-#include <ros/ros.h>
-#include <sensor_msgs/PointCloud2.h>
-#include <sensor_msgs/LaserScan.h>
-
-#include <float.h>
-
-// Laser projection
-#include <laser_geometry/laser_geometry.h>
-
-// TF
-#include <tf/transform_listener.h>
-#include "tf/message_filter.h"
-#include "message_filters/subscriber.h"
-
-//Filters
-#include "filters/filter_chain.h"
-
-/** @b ScanShadowsFilter is a simple node that filters shadow points in a laser scan line and publishes the results in a cloud.
- */
-class ScanToCloudFilterChain
+namespace laser_filters
 {
-public:
 
-  // ROS related
-  laser_geometry::LaserProjection projector_; // Used to project laser scans
-
-  double laser_max_range_;           // Used in laser scan projection
-  int window_;
-    
-  bool high_fidelity_;                    // High fidelity (interpolating time across scan)
-  std::string target_frame_;                   // Target frame for high fidelity result
-  std::string scan_topic_, cloud_topic_;
-
-  ros::NodeHandle nh;
-  ros::NodeHandle private_nh;
-    
-  // TF
-  tf::TransformListener tf_;
-
-  message_filters::Subscriber<sensor_msgs::LaserScan> sub_;
-  tf::MessageFilter<sensor_msgs::LaserScan> filter_;
-
-  double tf_tolerance_;
-  filters::FilterChain<sensor_msgs::PointCloud2> cloud_filter_chain_;
-  filters::FilterChain<sensor_msgs::LaserScan> scan_filter_chain_;
-  ros::Publisher cloud_pub_;
-
-  // Timer for displaying deprecation warnings
-  ros::Timer deprecation_timer_;
-  bool  using_scan_topic_deprecated_;
-  bool  using_cloud_topic_deprecated_;
-  bool  using_default_target_frame_deprecated_;
-  bool  using_laser_max_range_deprecated_;
-  bool  using_filter_window_deprecated_;
-  bool  using_scan_filters_deprecated_;
-  bool  using_cloud_filters_deprecated_;
-  bool  using_scan_filters_wrong_deprecated_;
-  bool  using_cloud_filters_wrong_deprecated_;
-  bool  incident_angle_correction_;
-
-  ////////////////////////////////////////////////////////////////////////////////
-  ScanToCloudFilterChain () : laser_max_range_ (DBL_MAX), private_nh("~"), filter_(tf_, "", 50),
-                   cloud_filter_chain_("sensor_msgs::PointCloud2"), scan_filter_chain_("sensor_msgs::LaserScan")
-  {
-    private_nh.param("high_fidelity", high_fidelity_, false);
-    private_nh.param("notifier_tolerance", tf_tolerance_, 0.03);
-    private_nh.param("target_frame", target_frame_, std::string ("base_link"));
-
-    // DEPRECATED with default value
-    using_default_target_frame_deprecated_ = !private_nh.hasParam("target_frame");
-
-    // DEPRECATED
-    using_scan_topic_deprecated_ = private_nh.hasParam("scan_topic");
-    using_cloud_topic_deprecated_ = private_nh.hasParam("cloud_topic");
-    using_laser_max_range_deprecated_ = private_nh.hasParam("laser_max_range");
-    using_filter_window_deprecated_ = private_nh.hasParam("filter_window");
-    using_cloud_filters_deprecated_ = private_nh.hasParam("cloud_filters/filter_chain");
-    using_scan_filters_deprecated_ = private_nh.hasParam("scan_filters/filter_chain");
-    using_cloud_filters_wrong_deprecated_ = private_nh.hasParam("cloud_filters/cloud_filter_chain");
-    using_scan_filters_wrong_deprecated_ = private_nh.hasParam("scan_filters/scan_filter_chain");
-
-
-    private_nh.param("filter_window", window_, 2);
-    private_nh.param("laser_max_range", laser_max_range_, DBL_MAX);
-    private_nh.param("scan_topic", scan_topic_, std::string("tilt_scan"));
-    private_nh.param("cloud_topic", cloud_topic_, std::string("tilt_laser_cloud_filtered"));
-    private_nh.param("incident_angle_correction", incident_angle_correction_, true);
-
-    filter_.setTargetFrame(target_frame_);
-    filter_.registerCallback(boost::bind(&ScanToCloudFilterChain::scanCallback, this, _1));
-    filter_.setTolerance(ros::Duration(tf_tolerance_));
-
-    if (using_scan_topic_deprecated_)
-      sub_.subscribe(nh, scan_topic_, 50);
-    else
-      sub_.subscribe(nh, "scan", 50);
-
-    filter_.connectInput(sub_);
-
-    if (using_cloud_topic_deprecated_)
-      cloud_pub_ = nh.advertise<sensor_msgs::PointCloud2> (cloud_topic_, 10);
-    else
-      cloud_pub_ = nh.advertise<sensor_msgs::PointCloud2> ("cloud_filtered", 10);
-
-    std::string cloud_filter_xml;
-
-    if (using_cloud_filters_deprecated_)
-      cloud_filter_chain_.configure("cloud_filters/filter_chain", private_nh);
-    else if (using_cloud_filters_wrong_deprecated_)
-      cloud_filter_chain_.configure("cloud_filters/cloud_filter_chain", private_nh);
-    else
-      cloud_filter_chain_.configure("cloud_filter_chain", private_nh);
-
-    if (using_scan_filters_deprecated_)
-      scan_filter_chain_.configure("scan_filter/filter_chain", private_nh);
-    else if (using_scan_filters_wrong_deprecated_)
-      scan_filter_chain_.configure("scan_filters/scan_filter_chain", private_nh);
-    else
-      scan_filter_chain_.configure("scan_filter_chain", private_nh);
-
-    deprecation_timer_ = nh.createTimer(ros::Duration(5.0), boost::bind(&ScanToCloudFilterChain::deprecation_warn, this, _1));
-  }
-
-  // We use a deprecation warning on a timer to avoid warnings getting lost in the noise
-  void deprecation_warn(const ros::TimerEvent& e)
-  {
-    if (using_scan_topic_deprecated_)
-      ROS_WARN("Use of '~scan_topic' parameter in scan_to_cloud_filter_chain has been deprecated.");
-
-    if (using_cloud_topic_deprecated_)
-      ROS_WARN("Use of '~cloud_topic' parameter in scan_to_cloud_filter_chain has been deprecated.");
-
-    if (using_laser_max_range_deprecated_)
-      ROS_WARN("Use of '~laser_max_range' parameter in scan_to_cloud_filter_chain has been deprecated.");
-
-    if (using_filter_window_deprecated_)
-      ROS_WARN("Use of '~filter_window' parameter in scan_to_cloud_filter_chain has been deprecated.");
-
-    if (using_default_target_frame_deprecated_)
-      ROS_WARN("Use of default '~target_frame' parameter in scan_to_cloud_filter_chain has been deprecated.  Default currently set to 'base_link' please set explicitly as appropriate.");
-
-    if (using_cloud_filters_deprecated_)
-      ROS_WARN("Use of '~cloud_filters/filter_chain' parameter in scan_to_cloud_filter_chain has been deprecated.  Replace with '~cloud_filter_chain'");
-
-    if (using_scan_filters_deprecated_)
-      ROS_WARN("Use of '~scan_filters/filter_chain' parameter in scan_to_cloud_filter_chain has been deprecated.  Replace with '~scan_filter_chain'");
-
-    if (using_cloud_filters_wrong_deprecated_)
-      ROS_WARN("Use of '~cloud_filters/cloud_filter_chain' parameter in scan_to_cloud_filter_chain is incorrect.  Please Replace with '~cloud_filter_chain'");
-
-    if (using_scan_filters_wrong_deprecated_)
-      ROS_WARN("Use of '~scan_filters/scan_filter_chain' parameter in scan_to_scan_filter_chain is incorrect.  Please Replace with '~scan_filter_chain'");
-
-  }
-
-
-  ////////////////////////////////////////////////////////////////////////////////
-  void
-  scanCallback (const sensor_msgs::LaserScan::ConstPtr& scan_msg)
-  {
-    //    sensor_msgs::LaserScan scan_msg = *scan_in;
-
-    sensor_msgs::LaserScan filtered_scan;
-    scan_filter_chain_.update (*scan_msg, filtered_scan);
-
-    // Project laser into point cloud
-    sensor_msgs::PointCloud2 scan_cloud;
-
-    //\TODO CLEAN UP HACK 
-    // This is a trial at correcting for incident angles.  It makes many assumptions that do not generalise
-    if(incident_angle_correction_)
-    {
-      for (unsigned int i = 0; i < filtered_scan.ranges.size(); i++)
-      {
-        double angle = filtered_scan.angle_min + i * filtered_scan.angle_increment;
-        filtered_scan.ranges[i] = filtered_scan.ranges[i] + 0.03 * exp(-fabs(sin(angle)));
-      }
-    }
-
-    // Transform into a PointCloud message
-    int mask = laser_geometry::channel_option::Intensity |
-      laser_geometry::channel_option::Distance |
-      laser_geometry::channel_option::Index |
-      laser_geometry::channel_option::Timestamp;
-      
-    if (high_fidelity_)
-    {
-      try
-      {
-        projector_.transformLaserScanToPointCloud (target_frame_, filtered_scan, scan_cloud, tf_, laser_max_range_, mask);
-      }
-      catch (tf::TransformException &ex)
-      {
-        ROS_WARN("High fidelity enabled, but TF returned a transform exception to frame %s: %s", target_frame_.c_str (), ex.what ());
-        return;
-        //projector_.projectLaser (filtered_scan, scan_cloud, laser_max_range_, preservative_, mask);
-      }
-    }
-    else
-    {
-      projector_.transformLaserScanToPointCloud(target_frame_, filtered_scan, scan_cloud, tf_, laser_max_range_, mask);
-    }
-      
-    sensor_msgs::PointCloud2 filtered_cloud;
-    cloud_filter_chain_.update (scan_cloud, filtered_cloud);
-
-    cloud_pub_.publish(filtered_cloud);
-  }
-
-} ;
-
-
-
-int
-main (int argc, char** argv)
+ScanToCloudFilterChain::ScanToCloudFilterChain(const ros::NodeHandle& nh, const ros::NodeHandle& pnh)
+  : laser_max_range_ (DBL_MAX),
+    nh_(nh),
+    private_nh_(pnh),
+    filter_(tf_, "", 50),
+    cloud_filter_chain_("sensor_msgs::PointCloud2"), scan_filter_chain_("sensor_msgs::LaserScan")
 {
-  ros::init (argc, argv, "scan_to_cloud_filter_chain");
-  ros::NodeHandle nh;
-  ScanToCloudFilterChain f;
+  private_nh_.param("high_fidelity", high_fidelity_, false);
+  private_nh_.param("notifier_tolerance", tf_tolerance_, 0.03);
+  private_nh_.param("target_frame", target_frame_, std::string ("base_link"));
 
-  ros::spin();
+  // DEPRECATED with default value
+  using_default_target_frame_deprecated_ = !private_nh_.hasParam("target_frame");
 
-  return (0);
+  // DEPRECATED
+  using_scan_topic_deprecated_ = private_nh_.hasParam("scan_topic");
+  using_cloud_topic_deprecated_ = private_nh_.hasParam("cloud_topic");
+  using_laser_max_range_deprecated_ = private_nh_.hasParam("laser_max_range");
+  using_filter_window_deprecated_ = private_nh_.hasParam("filter_window");
+  using_cloud_filters_deprecated_ = private_nh_.hasParam("cloud_filters/filter_chain");
+  using_scan_filters_deprecated_ = private_nh_.hasParam("scan_filters/filter_chain");
+  using_cloud_filters_wrong_deprecated_ = private_nh_.hasParam("cloud_filters/cloud_filter_chain");
+  using_scan_filters_wrong_deprecated_ = private_nh_.hasParam("scan_filters/scan_filter_chain");
+
+
+  private_nh_.param("filter_window", window_, 2);
+  private_nh_.param("laser_max_range", laser_max_range_, DBL_MAX);
+  private_nh_.param("scan_topic", scan_topic_, std::string("tilt_scan"));
+  private_nh_.param("cloud_topic", cloud_topic_, std::string("tilt_laser_cloud_filtered"));
+  private_nh_.param("incident_angle_correction", incident_angle_correction_, true);
+
+  filter_.setTargetFrame(target_frame_);
+  filter_.registerCallback(boost::bind(&ScanToCloudFilterChain::scanCallback, this, _1));
+  filter_.setTolerance(ros::Duration(tf_tolerance_));
+
+  if (using_scan_topic_deprecated_)
+    sub_.subscribe(nh_, scan_topic_, 50);
+  else
+    sub_.subscribe(nh_, "scan", 50);
+
+  filter_.connectInput(sub_);
+
+  if (using_cloud_topic_deprecated_)
+    cloud_pub_ = nh_.advertise<sensor_msgs::PointCloud2> (cloud_topic_, 10);
+  else
+    cloud_pub_ = nh_.advertise<sensor_msgs::PointCloud2> ("cloud_filtered", 10);
+
+  std::string cloud_filter_xml;
+
+  if (using_cloud_filters_deprecated_)
+    cloud_filter_chain_.configure("cloud_filters/filter_chain", private_nh_);
+  else if (using_cloud_filters_wrong_deprecated_)
+    cloud_filter_chain_.configure("cloud_filters/cloud_filter_chain", private_nh_);
+  else
+    cloud_filter_chain_.configure("cloud_filter_chain", private_nh_);
+
+  if (using_scan_filters_deprecated_)
+    scan_filter_chain_.configure("scan_filter/filter_chain", private_nh_);
+  else if (using_scan_filters_wrong_deprecated_)
+    scan_filter_chain_.configure("scan_filters/scan_filter_chain", private_nh_);
+  else
+    scan_filter_chain_.configure("scan_filter_chain", private_nh_);
+
+  deprecation_timer_ = nh_.createTimer(ros::Duration(5.0), boost::bind(&ScanToCloudFilterChain::deprecation_warn, this, _1));
 }
 
+void ScanToCloudFilterChain::deprecation_warn(const ros::TimerEvent& e)
+{
+  if (using_scan_topic_deprecated_)
+    ROS_WARN("Use of '~scan_topic' parameter in scan_to_cloud_filter_chain has been deprecated.");
 
+  if (using_cloud_topic_deprecated_)
+    ROS_WARN("Use of '~cloud_topic' parameter in scan_to_cloud_filter_chain has been deprecated.");
+
+  if (using_laser_max_range_deprecated_)
+    ROS_WARN("Use of '~laser_max_range' parameter in scan_to_cloud_filter_chain has been deprecated.");
+
+  if (using_filter_window_deprecated_)
+    ROS_WARN("Use of '~filter_window' parameter in scan_to_cloud_filter_chain has been deprecated.");
+
+  if (using_default_target_frame_deprecated_)
+    ROS_WARN("Use of default '~target_frame' parameter in scan_to_cloud_filter_chain has been deprecated.  Default currently set to 'base_link' please set explicitly as appropriate.");
+
+  if (using_cloud_filters_deprecated_)
+    ROS_WARN("Use of '~cloud_filters/filter_chain' parameter in scan_to_cloud_filter_chain has been deprecated.  Replace with '~cloud_filter_chain'");
+
+  if (using_scan_filters_deprecated_)
+    ROS_WARN("Use of '~scan_filters/filter_chain' parameter in scan_to_cloud_filter_chain has been deprecated.  Replace with '~scan_filter_chain'");
+
+  if (using_cloud_filters_wrong_deprecated_)
+    ROS_WARN("Use of '~cloud_filters/cloud_filter_chain' parameter in scan_to_cloud_filter_chain is incorrect.  Please Replace with '~cloud_filter_chain'");
+
+  if (using_scan_filters_wrong_deprecated_)
+    ROS_WARN("Use of '~scan_filters/scan_filter_chain' parameter in scan_to_scan_filter_chain is incorrect.  Please Replace with '~scan_filter_chain'");
+
+}
+
+void ScanToCloudFilterChain::scanCallback(const sensor_msgs::LaserScan::ConstPtr& scan_msg)
+{
+  //    sensor_msgs::LaserScan scan_msg = *scan_in;
+
+  sensor_msgs::LaserScan filtered_scan;
+  scan_filter_chain_.update (*scan_msg, filtered_scan);
+
+  // Project laser into point cloud
+  sensor_msgs::PointCloud2 scan_cloud;
+
+  //\TODO CLEAN UP HACK 
+  // This is a trial at correcting for incident angles.  It makes many assumptions that do not generalise
+  if(incident_angle_correction_)
+  {
+    for (unsigned int i = 0; i < filtered_scan.ranges.size(); i++)
+    {
+      double angle = filtered_scan.angle_min + i * filtered_scan.angle_increment;
+      filtered_scan.ranges[i] = filtered_scan.ranges[i] + 0.03 * exp(-fabs(sin(angle)));
+    }
+  }
+
+  // Transform into a PointCloud message
+  int mask = laser_geometry::channel_option::Intensity |
+    laser_geometry::channel_option::Distance |
+    laser_geometry::channel_option::Index |
+    laser_geometry::channel_option::Timestamp;
+    
+  if (high_fidelity_)
+  {
+    try
+    {
+      projector_.transformLaserScanToPointCloud (target_frame_, filtered_scan, scan_cloud, tf_, laser_max_range_, mask);
+    }
+    catch (tf::TransformException &ex)
+    {
+      ROS_WARN("High fidelity enabled, but TF returned a transform exception to frame %s: %s", target_frame_.c_str (), ex.what ());
+      return;
+      //projector_.projectLaser (filtered_scan, scan_cloud, laser_max_range_, preservative_, mask);
+    }
+  }
+  else
+  {
+    projector_.transformLaserScanToPointCloud(target_frame_, filtered_scan, scan_cloud, tf_, laser_max_range_, mask);
+  }
+    
+  sensor_msgs::PointCloud2 filtered_cloud;
+  cloud_filter_chain_.update (scan_cloud, filtered_cloud);
+
+  cloud_pub_.publish(filtered_cloud);
+}
+
+}  // namespace laser_filters

--- a/src/scan_to_cloud_filter_chain_node.cpp
+++ b/src/scan_to_cloud_filter_chain_node.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "laser_filters/scan_to_cloud_filter_chain.h"
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "scan_to_cloud_filter_chain");
+  
+  laser_filters::ScanToCloudFilterChain t(ros::NodeHandle(), ros::NodeHandle("~"));
+  ros::spin();
+  
+  return 0;
+}

--- a/src/scan_to_cloud_filter_chain_nodelet.cpp
+++ b/src/scan_to_cloud_filter_chain_nodelet.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "laser_filters/scan_to_cloud_filter_chain.h"
+#include <pluginlib/class_list_macros.h>
+#include <nodelet/nodelet.h>
+
+namespace laser_filters
+{
+
+class ScanToCloudFilterChainNodelet : public nodelet::Nodelet
+{
+public:
+  virtual void onInit()
+  {
+    chain_ptr_.reset(new ScanToCloudFilterChain(getNodeHandle(), getPrivateNodeHandle()));
+  }
+
+private:
+  boost::shared_ptr<ScanToCloudFilterChain> chain_ptr_;
+};
+
+}  // namespace laser_filters
+
+PLUGINLIB_EXPORT_CLASS(laser_filters::ScanToCloudFilterChainNodelet, nodelet::Nodelet)

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -26,122 +26,81 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#include "laser_filters/scan_to_scan_filter_chain.h"
 
-
-#include "ros/ros.h"
-#include "sensor_msgs/LaserScan.h"
-#include "message_filters/subscriber.h"
-#include "tf/message_filter.h"
-#include "tf/transform_listener.h"
-#include "filters/filter_chain.h"
-
-class ScanToScanFilterChain
+namespace laser_filters
 {
-protected:
-  // Our NodeHandle
-  ros::NodeHandle nh_;
-  ros::NodeHandle private_nh_;
 
-  // Components for tf::MessageFilter
-  tf::TransformListener *tf_;
-  message_filters::Subscriber<sensor_msgs::LaserScan> scan_sub_;
-  tf::MessageFilter<sensor_msgs::LaserScan> *tf_filter_;
-  double tf_filter_tolerance_;
-
-  // Filter Chain
-  filters::FilterChain<sensor_msgs::LaserScan> filter_chain_;
-
-  // Components for publishing
-  sensor_msgs::LaserScan msg_;
-  ros::Publisher output_pub_;
-
-  // Deprecation helpers
-  ros::Timer deprecation_timer_;
-  bool  using_filter_chain_deprecated_;
-
-public:
-  // Constructor
-  ScanToScanFilterChain() :
-    private_nh_("~"),
+ScanToScanFilterChain::ScanToScanFilterChain(const ros::NodeHandle& nh, const ros::NodeHandle& pnh)
+  : nh_(nh),
+    private_nh_(pnh),
     scan_sub_(nh_, "scan", 50),
     tf_(NULL),
     tf_filter_(NULL),
     filter_chain_("sensor_msgs::LaserScan")
-  {
-    // Configure filter chain
-    
-    using_filter_chain_deprecated_ = private_nh_.hasParam("filter_chain");
-
-    if (using_filter_chain_deprecated_)
-      filter_chain_.configure("filter_chain", private_nh_);
-    else
-      filter_chain_.configure("scan_filter_chain", private_nh_);
-    
-    std::string tf_message_filter_target_frame;
-
-    if (private_nh_.hasParam("tf_message_filter_target_frame"))
-    {
-      private_nh_.getParam("tf_message_filter_target_frame", tf_message_filter_target_frame);
-
-      private_nh_.param("tf_message_filter_tolerance", tf_filter_tolerance_, 0.03);
-
-      tf_ = new tf::TransformListener();
-      tf_filter_ = new tf::MessageFilter<sensor_msgs::LaserScan>(scan_sub_, *tf_, "", 50);
-      tf_filter_->setTargetFrame(tf_message_filter_target_frame);
-      tf_filter_->setTolerance(ros::Duration(tf_filter_tolerance_));
-
-      // Setup tf::MessageFilter generates callback
-      tf_filter_->registerCallback(boost::bind(&ScanToScanFilterChain::callback, this, _1));
-    }
-    else 
-    {
-      // Pass through if no tf_message_filter_target_frame
-      scan_sub_.registerCallback(boost::bind(&ScanToScanFilterChain::callback, this, _1));
-    }
-    
-    // Advertise output
-    output_pub_ = nh_.advertise<sensor_msgs::LaserScan>("scan_filtered", 1000);
-
-    // Set up deprecation printout
-    deprecation_timer_ = nh_.createTimer(ros::Duration(5.0), boost::bind(&ScanToScanFilterChain::deprecation_warn, this, _1));
-  }
-
-  // Destructor
-  ~ScanToScanFilterChain()
-  {
-    if (tf_filter_)
-      delete tf_filter_;
-    if (tf_)
-      delete tf_;
-  }
-  
-  // Deprecation warning callback
-  void deprecation_warn(const ros::TimerEvent& e)
-  {
-    if (using_filter_chain_deprecated_)
-      ROS_WARN("Use of '~filter_chain' parameter in scan_to_scan_filter_chain has been deprecated. Please replace with '~scan_filter_chain'.");
-  }
-
-  // Callback
-  void callback(const sensor_msgs::LaserScan::ConstPtr& msg_in)
-  {
-    // Run the filter chain
-    if (filter_chain_.update(*msg_in, msg_))
-    {
-      //only publish result if filter succeeded
-      output_pub_.publish(msg_);
-    } else {
-      ROS_ERROR_THROTTLE(1, "Filtering the scan from time %i.%i failed.", msg_in->header.stamp.sec, msg_in->header.stamp.nsec);
-    }
-  }
-};
-
-int main(int argc, char **argv)
 {
-  ros::init(argc, argv, "scan_to_scan_filter_chain");
+  // Configure filter chain
   
-  ScanToScanFilterChain t;
-  ros::spin();
+  using_filter_chain_deprecated_ = private_nh_.hasParam("filter_chain");
+
+  if (using_filter_chain_deprecated_)
+    filter_chain_.configure("filter_chain", private_nh_);
+  else
+    filter_chain_.configure("scan_filter_chain", private_nh_);
   
-  return 0;
+  std::string tf_message_filter_target_frame;
+
+  if (private_nh_.hasParam("tf_message_filter_target_frame"))
+  {
+    private_nh_.getParam("tf_message_filter_target_frame", tf_message_filter_target_frame);
+
+    private_nh_.param("tf_message_filter_tolerance", tf_filter_tolerance_, 0.03);
+
+    tf_ = new tf::TransformListener();
+    tf_filter_ = new tf::MessageFilter<sensor_msgs::LaserScan>(scan_sub_, *tf_, "", 50);
+    tf_filter_->setTargetFrame(tf_message_filter_target_frame);
+    tf_filter_->setTolerance(ros::Duration(tf_filter_tolerance_));
+
+    // Setup tf::MessageFilter generates callback
+    tf_filter_->registerCallback(boost::bind(&ScanToScanFilterChain::callback, this, _1));
+  }
+  else 
+  {
+    // Pass through if no tf_message_filter_target_frame
+    scan_sub_.registerCallback(boost::bind(&ScanToScanFilterChain::callback, this, _1));
+  }
+  
+  // Advertise output
+  output_pub_ = nh_.advertise<sensor_msgs::LaserScan>("scan_filtered", 1000);
+
+  // Set up deprecation printout
+  deprecation_timer_ = nh_.createTimer(ros::Duration(5.0), boost::bind(&ScanToScanFilterChain::deprecation_warn, this, _1));
 }
+
+ScanToScanFilterChain::~ScanToScanFilterChain()
+{
+  if (tf_filter_)
+    delete tf_filter_;
+  if (tf_)
+    delete tf_;
+}
+  
+void ScanToScanFilterChain::deprecation_warn(const ros::TimerEvent& e)
+{
+  if (using_filter_chain_deprecated_)
+    ROS_WARN("Use of '~filter_chain' parameter in scan_to_scan_filter_chain has been deprecated. Please replace with '~scan_filter_chain'.");
+}
+
+void ScanToScanFilterChain::callback(const sensor_msgs::LaserScan::ConstPtr& msg_in)
+{
+  // Run the filter chain
+  if (filter_chain_.update(*msg_in, msg_))
+  {
+    //only publish result if filter succeeded
+    output_pub_.publish(msg_);
+  } else {
+    ROS_ERROR_THROTTLE(1, "Filtering the scan from time %i.%i failed.", msg_in->header.stamp.sec, msg_in->header.stamp.nsec);
+  }
+}
+
+}  // namespace laser_filters

--- a/src/scan_to_scan_filter_chain_node.cpp
+++ b/src/scan_to_scan_filter_chain_node.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "laser_filters/scan_to_scan_filter_chain.h"
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "scan_to_scan_filter_chain");
+  
+  laser_filters::ScanToScanFilterChain t(ros::NodeHandle(), ros::NodeHandle("~"));
+  ros::spin();
+  
+  return 0;
+}

--- a/src/scan_to_scan_filter_chain_nodelet.cpp
+++ b/src/scan_to_scan_filter_chain_nodelet.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "laser_filters/scan_to_scan_filter_chain.h"
+#include <pluginlib/class_list_macros.h>
+#include <nodelet/nodelet.h>
+
+namespace laser_filters
+{
+
+class ScanToScanFilterChainNodelet : public nodelet::Nodelet
+{
+public:
+  virtual void onInit()
+  {
+    chain_ptr_.reset(new ScanToScanFilterChain(getNodeHandle(), getPrivateNodeHandle()));
+  }
+
+private:
+  boost::shared_ptr<ScanToScanFilterChain> chain_ptr_;
+};
+
+}  // namespace laser_filters
+
+PLUGINLIB_EXPORT_CLASS(laser_filters::ScanToScanFilterChainNodelet, nodelet::Nodelet)


### PR DESCRIPTION
Split the ROS filter chain functionality from the node into its own
class for both the scan-to-scan and scan-to-cloud nodes.

Add nodelets for both using the new filter chain classes.