### PR TITLE
New filter for radius outlier removal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 # dynamic reconfigure
 generate_dynamic_reconfigure_options(
   cfg/ScanShadowsFilter.cfg
+  cfg/RadiusOutlierFilter.cfg
 )
 
 catkin_package(

--- a/cfg/RadiusOutlierFilter.cfg
+++ b/cfg/RadiusOutlierFilter.cfg
@@ -42,6 +42,6 @@ gen = ParameterGenerator()
 
 gen.add("radius_search", double_t, 0, "Maximum allowed point distance", 0.4, 0, 10.0)
 gen.add("window", int_t, 0, "Number of consecutive measurements to consider", 1, 1, 100)
-gen.add("min_neighbors", int_t, 0, "Minimum number of neighbors", 20, 1, 100)
+gen.add("min_neighbors", int_t, 0, "Minimum number of neighbors", 20, 0, 100)
 
 exit(gen.generate(PACKAGE, "laser_filters", "RadiusOutlierFilter"))

--- a/cfg/RadiusOutlierFilter.cfg
+++ b/cfg/RadiusOutlierFilter.cfg
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+#
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2020, Nicolas Limpert
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the TNO IVS nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# \author Nicolas Limpert
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+PACKAGE = "laser_filters"
+
+gen = ParameterGenerator()
+
+gen.add("radius_search", double_t, 0, "Maximum allowed point distance", 0.4, 0, 10.0)
+gen.add("window", int_t, 0, "Number of consecutive measurements to consider", 1, 1, 100)
+gen.add("min_neighbors", int_t, 0, "Minimum number of neighbors", 20, 1, 100)
+
+exit(gen.generate(PACKAGE, "laser_filters", "RadiusOutlierFilter"))

--- a/examples/radius_outlier_example.launch
+++ b/examples/radius_outlier_example.launch
@@ -1,6 +1,5 @@
 <launch>
 <node pkg="laser_filters" type="scan_to_scan_filter_chain" output="screen" name="laser_filter">
-      <!--remap from="scan" to="base_scan" /-->
       <rosparam command="load" file="$(find laser_filters)/examples/radius_outlier_example.yaml" />
 </node>
 </launch>

--- a/examples/radius_outlier_example.launch
+++ b/examples/radius_outlier_example.launch
@@ -1,0 +1,6 @@
+<launch>
+<node pkg="laser_filters" type="scan_to_scan_filter_chain" output="screen" name="laser_filter">
+      <!--remap from="scan" to="base_scan" /-->
+      <rosparam command="load" file="$(find laser_filters)/examples/radius_outlier_example.yaml" />
+</node>
+</launch>

--- a/examples/radius_outlier_example.yaml
+++ b/examples/radius_outlier_example.yaml
@@ -1,0 +1,7 @@
+scan_filter_chain:
+- name: radiusoutlier
+  type: laser_filters/RadiusOutlierFilter
+  params:
+    radius_search: 0.4
+    min_neighbors: 10
+    window: 10

--- a/include/laser_filters/radius_outlier_detector.h
+++ b/include/laser_filters/radius_outlier_detector.h
@@ -1,0 +1,101 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2020, Nicolas Limpert
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/*
+\author Nicolas Limpert <limpert@fh-aachen.de>
+*/
+
+#ifndef RADIUS_OUTLIER_DETECTOR_H
+#define RADIUS_OUTLIER_DETECTOR_H
+
+#include <angles/angles.h>
+
+namespace laser_filters
+{
+class RadiusOutlierDetector
+{
+public:
+  float radius_search_;
+
+  void configure(const float radius_search)
+  {
+    radius_search_ = radius_search;
+  }
+
+  bool isNeighbor(const float r1, const float r2, const float included_angle)
+  {
+    // Explanation:
+    //
+    // Distance between two points:
+    // d² = (x2 - x1)² + (y2 - y1)²
+    //
+    // Substitute x with r * cos(phi) and y with r * sin(phi):
+    // d² = (r2 * cos(phi2) - r1 * cos(phi1))² + (r2 * sin(phi2) - r1 * sin(phi1))²
+    //
+    // Apply binomial theorem:
+    // d² = ((r2² * cos(phi2)² + r1² * cos(phi1)² - 2 * r1 * r2 * cos(phi1) * cos(phi2)) +
+    //      ((r2² * sin(phi2)² + r1² * sin(phi1)² - 2 * r1 * r2 * sin(phi1) * sin(phi2))
+    //
+    // Merge sums:
+    // d² = r2² * (cos(phi2)² + sin(phi2)²) + r1² * (cos(phi1)² + sin(phi1)² -
+    //      2 * r1 * r2 * (cos(phi1) * cos(phi2) + sin(phi1) * sin(phi2))
+    //
+    // Apply cos² + sin² = 1:
+    // d² = r2² + r1² - 2 * r1 * r2 * (cos(phi1) * cos(phi2) + sin(phi1) * sin(phi2))
+    //
+    // Note the following:
+    // cos(phi1) * cos(phi2) = 1/2 * (cos(phi1 - phi2) + cos(phi1 + phi2))
+    // sin(phi1) * sin(phi2) = 1/2 * (cos(phi1 - phi2) - cos(phi1 + phi2))
+    //
+    // cos(phi1) * cos(phi2) + sin(phi1) * sin(phi2) = cos(phi1 - phi2)
+    //
+    // Finally, phi1 - phi2 is our included_angle.
+
+    const float d = sqrt(
+          pow(r1,2) + pow(r2,2) -
+          (2 * r1 * r2 * cosf(included_angle)));
+
+    if (d <= radius_search_)
+    {
+      return true;
+    }
+    else
+    {
+      return false;
+    }
+  }
+};
+}
+
+#endif  //RADIUS_OUTLIER_DETECTOR_H

--- a/include/laser_filters/radius_outlier_filter.h
+++ b/include/laser_filters/radius_outlier_filter.h
@@ -144,7 +144,7 @@ public:
 
     std::set<int> indices_to_delete;
     // For each point in the current line scan
-    for (unsigned int i = 0; i < scan_in.ranges.size(); i++)
+    for (int i = 0; i < static_cast<int>(scan_in.ranges.size()); i++)
     {
       int num_neighbors = 0;
 
@@ -154,7 +154,7 @@ public:
       {
         int j = i + y;
 
-        if (j < 0 || j >= (int)scan_in.ranges.size() || (int)i == j || std::isnan(scan_in.ranges[j]))
+        if (j < 0 || j >= static_cast<int>(scan_in.ranges.size()) || i == j || std::isnan(scan_in.ranges[j]))
         {  // Out of scan bounds or itself or infinity
           continue;
         }
@@ -172,7 +172,7 @@ public:
     }
 
     ROS_DEBUG("RadiusOutlierFilter removing %d/%d Points from scan",
-              (int)indices_to_delete.size(), (int) scan_in.ranges.size());
+              static_cast<int>(indices_to_delete.size()), static_cast<int>(scan_in.ranges.size()));
     for (std::set<int>::iterator it = indices_to_delete.begin(); it != indices_to_delete.end(); ++it)
     {
       scan_out.ranges[*it] = std::numeric_limits<float>::quiet_NaN();  // Failed test to set the ranges to invalid value

--- a/include/laser_filters/radius_outlier_filter.h
+++ b/include/laser_filters/radius_outlier_filter.h
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2020 Nicolas Limpert <limpert@fh-aachen.de>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+/*
+  \author Nicolas Limpert <limpert@fh-aachen.de>
+
+
+*/
+
+#ifndef LASER_SCAN_RADIUS_OUTLIER_FILTER_H
+#define LASER_SCAN_RADIUS_OUTLIER_FILTER_H
+
+#include <set>
+
+#include <filters/filter_base.h>
+#include <laser_filters/radius_outlier_detector.h>
+#include <laser_filters/RadiusOutlierFilterConfig.h>
+#include <dynamic_reconfigure/server.h>
+#include <sensor_msgs/LaserScan.h>
+#include <angles/angles.h>
+#include <math.h>
+
+
+namespace laser_filters
+{
+/** @b RadiusOutlierFilter filters scan points that don't have at least
+ *     some number of neighbors within a certain range.
+ */
+
+class RadiusOutlierFilter : public filters::FilterBase<sensor_msgs::LaserScan>
+{
+public:
+  double radius_search_;
+  int window_, min_neighbors_;
+
+  RadiusOutlierDetector radius_detector_;
+
+  std::shared_ptr<dynamic_reconfigure::Server<laser_filters::RadiusOutlierFilterConfig>> dyn_server_;
+  boost::recursive_mutex own_mutex_;
+  RadiusOutlierFilterConfig param_config;
+
+  ////////////////////////////////////////////////////////////////////////////////
+  RadiusOutlierFilter()
+  {
+  }
+
+  /**@b Configure the filter from XML */
+  bool configure()
+  {
+    ros::NodeHandle private_nh("~" + getName());
+    dyn_server_.reset(new dynamic_reconfigure::Server<laser_filters::RadiusOutlierFilterConfig>(own_mutex_, private_nh));
+    dynamic_reconfigure::Server<laser_filters::RadiusOutlierFilterConfig>::CallbackType f;
+    f = boost::bind(&laser_filters::RadiusOutlierFilter::reconfigureCB, this, _1, _2);
+    dyn_server_->setCallback(f);
+
+    if (!filters::FilterBase<sensor_msgs::LaserScan>::getParam(std::string("radius_search"), radius_search_))
+    {
+      ROS_ERROR("Error: RadiusOutlierFilter was not given radius_search.\n");
+      return false;
+    }
+    if (!filters::FilterBase<sensor_msgs::LaserScan>::getParam(std::string("min_neighbors"), min_neighbors_))
+    {
+      ROS_ERROR("Error: RadiusOutlierFilter was not given min_neighbors.\n");
+      return false;
+    }
+    if (!filters::FilterBase<sensor_msgs::LaserScan>::getParam(std::string("window"), window_))
+    {
+      ROS_ERROR("Error: RadiusOutlierFilter was not given window.\n");
+      return false;
+    }
+
+    if (radius_search_ < 0)
+    {
+      ROS_ERROR("radius_search must be >= 0. Forcing radius_search = 0.");
+      radius_search_ = 0.0;
+    }
+
+    if (min_neighbors_ < 0)
+    {
+      ROS_ERROR("min_neighbors must be >= 0. Forcing min_neighbors = 0");
+      min_neighbors_ = 0;
+    }
+    radius_detector_.configure(radius_search_);
+
+    param_config.radius_search = radius_search_;
+    param_config.window = window_;
+    param_config.min_neighbors = min_neighbors_;
+    dyn_server_->updateConfig(param_config);
+
+    return true;
+  }
+
+  void reconfigureCB(RadiusOutlierFilterConfig& config, uint32_t level)
+  {
+    radius_search_ = config.radius_search;
+    window_ = config.window;
+    min_neighbors_ = config.min_neighbors;
+
+    radius_detector_.configure(radius_search_);
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////
+  virtual ~RadiusOutlierFilter()
+  {
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////
+  /** \brief Filter points based on 3 global parameters: radius_search, min_neighbors and
+   * window. The radius_search specifies the maximum allowed distance for
+   * points to be neighbors. The min_neighbors specifies how many neighboring points
+   * have to be found (within radius_search being the maximum allowed distance) to consider
+   * the point to be valid. The window parameter specifies how many consecutive measurements
+   * to take into account for one point.
+   * \param scan_in the input LaserScan message
+   * \param scan_out the output LaserScan message
+   */
+  bool update(const sensor_msgs::LaserScan& scan_in, sensor_msgs::LaserScan& scan_out)
+  {
+    boost::recursive_mutex::scoped_lock lock(own_mutex_);
+    // copy across all data first
+    scan_out = scan_in;
+
+    std::set<int> indices_to_delete;
+    // For each point in the current line scan
+    for (unsigned int i = 0; i < scan_in.ranges.size(); i++)
+    {
+      int num_neighbors = 0;
+
+      // Look around the current point until either the window is exceeded
+      // or the number of neighbors was found.
+      for (int y = -window_; y < window_ + 1 && num_neighbors < min_neighbors_; y++)
+      {
+        int j = i + y;
+
+        if (j < 0 || j >= (int)scan_in.ranges.size() || (int)i == j || std::isnan(scan_in.ranges[j]))
+        {  // Out of scan bounds or itself or infinity
+          continue;
+        }
+
+        if (radius_detector_.isNeighbor(scan_in.ranges[i], scan_in.ranges[j], y * scan_in.angle_increment))
+        {
+          num_neighbors++;
+        }
+      }
+
+      if (num_neighbors < min_neighbors_)
+      {
+        indices_to_delete.insert(i);
+      }
+    }
+
+    ROS_DEBUG("RadiusOutlierFilter removing %d/%d Points from scan",
+              (int)indices_to_delete.size(), (int) scan_in.ranges.size());
+    for (std::set<int>::iterator it = indices_to_delete.begin(); it != indices_to_delete.end(); ++it)
+    {
+      scan_out.ranges[*it] = std::numeric_limits<float>::quiet_NaN();  // Failed test to set the ranges to invalid value
+    }
+    return true;
+  }
+
+  ////////////////////////////////////////////////////////////////////////////////
+};
+}
+
+#endif  // LASER_SCAN_RADIUS_OUTLIER_FILTER_H

--- a/include/laser_filters/radius_outlier_filter.h
+++ b/include/laser_filters/radius_outlier_filter.h
@@ -64,7 +64,6 @@ public:
   boost::recursive_mutex own_mutex_;
   RadiusOutlierFilterConfig param_config;
 
-  ////////////////////////////////////////////////////////////////////////////////
   RadiusOutlierFilter()
   {
   }
@@ -124,12 +123,10 @@ public:
     radius_detector_.configure(radius_search_);
   }
 
-  ////////////////////////////////////////////////////////////////////////////////
   virtual ~RadiusOutlierFilter()
   {
   }
 
-  ////////////////////////////////////////////////////////////////////////////////
   /** \brief Filter points based on 3 global parameters: radius_search, min_neighbors and
    * window. The radius_search specifies the maximum allowed distance for
    * points to be neighbors. The min_neighbors specifies how many neighboring points
@@ -183,7 +180,6 @@ public:
     return true;
   }
 
-  ////////////////////////////////////////////////////////////////////////////////
 };
 }
 

--- a/laser_filters_plugins.xml
+++ b/laser_filters_plugins.xml
@@ -18,6 +18,12 @@
 	This is a filter which filters sensor_msgs::LaserScan messages based on range
       </description>
     </class>
+    <class name="laser_filters/RadiusOutlierFilter" type="laser_filters::RadiusOutlierFilter"
+	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+      <description>
+	This is a filter which removes points that do not have a user defined number of neighbors in a certain radius around the particular point.
+      </description>
+    </class>
     <class name="laser_filters/ScanShadowsFilter" type="laser_filters::ScanShadowsFilter" 
 	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>

--- a/src/laser_scan_filters.cpp
+++ b/src/laser_scan_filters.cpp
@@ -31,6 +31,7 @@
 #include "laser_filters/array_filter.h"
 #include "laser_filters/intensity_filter.h"
 #include "laser_filters/range_filter.h"
+#include "laser_filters/radius_outlier_filter.h"
 #include "laser_filters/scan_mask_filter.h"
 #include "laser_filters/scan_shadows_filter.h"
 #include "laser_filters/footprint_filter.h"
@@ -52,6 +53,7 @@ PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanRangeFilter, filters::FilterBase<
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanAngularBoundsFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanAngularBoundsFilterInPlace, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanFootprintFilter, filters::FilterBase<sensor_msgs::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::RadiusOutlierFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::ScanShadowsFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::InterpolationFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanBoxFilter, filters::FilterBase<sensor_msgs::LaserScan>)


### PR DESCRIPTION
This PR adds a new filter inspired by PCL's [`RadiusOutlierRemoval`](http://pointclouds.org/documentation/tutorials/remove_outliers.php) to allow a radius-based filtering based on plain distances between points.
I found this useful to overcome sensor noise being problematic specially for navigation purposes, where false-positive measurements are marked as obstacles. In contrast I couldn't figure out how to properly configure the `ScanShadowFilter` to achieve a robust filtering of generic sensor noise.

The implementation is based on (and also inspired by) the `ScanShadowFilter`.

The `radius_search` parameter specifies the maximum allowed distance of a neighboring point to be considered as a valid neighbor.
The parameter `min_neighbors` specifies how many neighbors have to be found to consider the point to remain in the output.
The `window` parameter specifies how many consecutive measurements to take into account.


The following screenshot shows a sample of a robot running the new filter:
![Screenshot of robot running radius_outlier_filter](https://fh-aachen.sciebo.de/s/XiNgwNMBDcMK1At/download)
The laser measurements colored in magenta represent the raw, unfiltered laser while the cyan ones are the filtered measurements.
The configuration of this scenario is the same as found in the example - being:
```
    radius_search: 0.4
    min_neighbors: 10
    window: 10
```

I have also created a video demonstrating the new filter:
https://fh-aachen.sciebo.de/s/Mf9QgE8SMC8y3Aw
Note that in this video RViz is configured with `Decay Time = 2` for the filtered laser to highlight the result.