### PR TITLE
feat(IntensityFilter): Dynamic reconfigure and optionally override intensity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ include_directories(include ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 
 # dynamic reconfigure
 generate_dynamic_reconfigure_options(
+  cfg/IntensityFilter.cfg
   cfg/PolygonFilter.cfg
   cfg/ScanShadowsFilter.cfg
   cfg/RadiusOutlierFilter.cfg
@@ -45,6 +46,7 @@ add_library(laser_scan_filters
   src/array_filter.cpp
   src/box_filter.cpp
   src/polygon_filter.cpp
+  src/intensity_filter.cpp
 )
 target_link_libraries(laser_scan_filters ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 

--- a/cfg/IntensityFilter.cfg
+++ b/cfg/IntensityFilter.cfg
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#
+# Software License Agreement (BSD License)
+#
+# Copyright (c) 2020, Eurotec, Netherlands
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#  * Neither the name of the TNO IVS nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# \author Rein Appeldoorn
+
+from dynamic_reconfigure.parameter_generator_catkin import *
+
+PACKAGE = "laser_filters"
+
+gen = ParameterGenerator()
+
+gen.add("lower_threshold", double_t, 0,
+        "Intensity values lower than this value will be filtered", 8000.0, 0, 100000.0)
+gen.add("upper_threshold", double_t, 0,
+        "Intensity values greater than this value will be filtered", 100000.0, 0, 100000.0)
+gen.add("invert", bool_t, 0, "A Boolean to invert the filter", False)
+
+gen.add("filter_override_range", bool_t, 0,
+        "Whether to set the filtered laser beam ranges to NaN", True)
+gen.add("filter_override_intensity", bool_t, 0,
+        "Whether to set the filtered and non-filtered laser beam intensities to 0.0 and 1.0 respectively", False)
+
+exit(gen.generate(PACKAGE, "laser_filters", "IntensityFilter"))

--- a/examples/intensity_filter_example.yaml
+++ b/examples/intensity_filter_example.yaml
@@ -1,7 +1,9 @@
 scan_filter_chain:
 - name: intensity
-  type: LaserScanIntensityFilter
+  type: laser_filters/LaserScanIntensityFilter
   params:
     lower_threshold: 8000
     upper_threshold: 100000
-    disp_histogram: 0
+    invert: false
+    filter_override_range: true
+    filter_override_intensity: false

--- a/include/laser_filters/intensity_filter.h
+++ b/include/laser_filters/intensity_filter.h
@@ -2,6 +2,7 @@
 * Software License Agreement (BSD License)
 * 
 *  Copyright (c) 2008, Willow Garage, Inc.
+*  Copyright (c) 2020, Eurotec B.V.
 *  All rights reserved.
 * 
 *  Redistribution and use in source and binary forms, with or without
@@ -30,103 +31,32 @@
 *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 *  POSSIBILITY OF SUCH DAMAGE.
+*
+*  \author Vijay Pradeep, Rein Appeldoorn
+*
 *********************************************************************/
 
-#ifndef LASER_SCAN_INTENSITY_FILTER_H
-#define LASER_SCAN_INTENSITY_FILTER_H
-/**
-\author Vijay Pradeep
-@b ScanIntensityFilter takes input scans and fiters out that are not within the specified range. The filtered out readings are set at >max_range in order to invalidate them.
+#pragma once
 
-**/
-
-
-#include "filters/filter_base.h"
-#include "sensor_msgs/LaserScan.h"
+#include <dynamic_reconfigure/server.h>
+#include <filters/filter_base.h>
+#include <laser_filters/IntensityFilterConfig.h>
+#include <sensor_msgs/LaserScan.h>
 
 namespace laser_filters
 {
-
 class LaserScanIntensityFilter : public filters::FilterBase<sensor_msgs::LaserScan>
 {
 public:
+  LaserScanIntensityFilter();
+  bool configure();
+  bool update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& output_scan);
 
-  double lower_threshold_ ;
-  double upper_threshold_ ;
-  int disp_hist_ ;
-  bool disp_hist_enabled_;
+private:
+  std::shared_ptr<dynamic_reconfigure::Server<IntensityFilterConfig>> dyn_server_;
+  void reconfigureCB(IntensityFilterConfig& config, uint32_t level);
+  boost::recursive_mutex own_mutex_;
 
-  bool configure()
-  {
-    lower_threshold_ = 8000.0;
-    upper_threshold_ = 100000.0;
-    disp_hist_ = 1;
-    getParam("lower_threshold", lower_threshold_);
-    getParam("upper_threshold", upper_threshold_) ;
-    getParam("disp_histogram",  disp_hist_) ;
-
-    disp_hist_enabled_ = (disp_hist_ == 0) ? false : true;
-
-    return true;
-  }
-
-  virtual ~LaserScanIntensityFilter(){}
-
-  bool update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& filtered_scan)
-  {
-    const double hist_max = 4*12000.0 ;
-    const int num_buckets = 24 ;
-    int histogram[num_buckets] ;
-    for (int i=0; i < num_buckets; i++)
-      histogram[i] = 0 ;
-
-    filtered_scan = input_scan;
-
-    // Need to check ever reading in the current scan
-    for (unsigned int i=0;
-         i < input_scan.ranges.size() && i < input_scan.intensities.size();
-         i++)
-    {
-      // Is this reading below our lower threshold?
-      // Is this reading above our upper threshold?
-      if (filtered_scan.intensities[i] <= lower_threshold_ ||
-          filtered_scan.intensities[i] >= upper_threshold_)
-      {
-        // If so, then make it an invalid value (NaN)
-        filtered_scan.ranges[i] = std::numeric_limits<float>::quiet_NaN();
-      }
-
-      // Calculate histogram
-      if (disp_hist_enabled_){
-        // If intensity value is inf or NaN, skip voting histogram
-        if( std::isinf((double)filtered_scan.intensities[i]) ||
-            std::isnan((double)filtered_scan.intensities[i]) )
-          continue;
-
-        // Choose bucket to vote on histogram,
-        // and check the index of bucket is in the histogram array
-        int cur_bucket = (int)(filtered_scan.intensities[i] / hist_max * num_buckets);
-        if (cur_bucket > num_buckets-1)
-          cur_bucket = num_buckets-1;
-        else if (cur_bucket < 0) cur_bucket = 0;
-        histogram[cur_bucket]++;
-      }
-    }
-
-    // Display Histogram
-    if (disp_hist_enabled_)
-    {
-      printf("********** SCAN **********\n") ;
-      for (int i=0; i < num_buckets; i++)
-      {
-        printf("%u - %u: %u\n", (unsigned int) hist_max/num_buckets*i,
-                                (unsigned int) hist_max/num_buckets*(i+1),
-                                histogram[i]) ;
-      }
-    }
-    return true;
-  }
+  IntensityFilterConfig config_ = IntensityFilterConfig::__getDefault__();
 };
 }
-
-#endif // LASER_SCAN_INTENSITY_FILTER_H

--- a/src/intensity_filter.cpp
+++ b/src/intensity_filter.cpp
@@ -1,0 +1,112 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2008, Willow Garage, Inc.
+*  Copyright (c) 2020, Eurotec B.V.
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*
+*  \author Vijay Pradeep, Rein Appeldoorn
+*
+*********************************************************************/
+
+#include <laser_filters/intensity_filter.h>
+#include <ros/node_handle.h>
+
+namespace laser_filters
+{
+LaserScanIntensityFilter::LaserScanIntensityFilter()
+{
+}
+
+bool LaserScanIntensityFilter::configure()
+{
+  ros::NodeHandle private_nh("~" + getName());
+  dyn_server_.reset(new dynamic_reconfigure::Server<IntensityFilterConfig>(own_mutex_, private_nh));
+  dynamic_reconfigure::Server<IntensityFilterConfig>::CallbackType f;
+  f = boost::bind(&LaserScanIntensityFilter::reconfigureCB, this, _1, _2);
+  dyn_server_->setCallback(f);
+
+  getParam("lower_threshold", config_.lower_threshold);
+  getParam("upper_threshold", config_.upper_threshold);
+  getParam("invert", config_.invert);
+
+  getParam("filter_override_range", config_.filter_override_range);
+  getParam("filter_override_intensity", config_.filter_override_intensity);
+  dyn_server_->updateConfig(config_);
+  return true;
+}
+
+bool LaserScanIntensityFilter::update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& filtered_scan)
+{
+  filtered_scan = input_scan;
+
+  // Need to check ever reading in the current scan
+  for (unsigned int i=0; i < input_scan.ranges.size() && i < input_scan.intensities.size(); i++)
+  {
+    float& range = filtered_scan.ranges[i];
+    float& intensity = filtered_scan.intensities[i];
+
+    // Is this reading below our lower threshold?
+    // Is this reading above our upper threshold?
+    bool filter = intensity <= config_.lower_threshold || intensity >= config_.upper_threshold;
+    if (config_.invert)
+    {
+      filter = !filter;
+    }
+
+    if (filter)
+    {
+      if (config_.filter_override_range)
+      {
+        // If so, then make it an invalid value (NaN)
+        range = std::numeric_limits<float>::quiet_NaN();
+      }
+      if (config_.filter_override_intensity)
+      {
+        intensity = 0.0;  // Not intense
+      }
+    }
+    else
+    {
+      if (config_.filter_override_intensity)
+      {
+        intensity = 1.0;  // Intense
+      }
+    }
+  }
+
+  return true;
+}
+
+void LaserScanIntensityFilter::reconfigureCB(IntensityFilterConfig& config, uint32_t level)
+{
+  config_ = config;
+}
+}


### PR DESCRIPTION
- Dynamic reconfigure for IntensityFilter
- Removed printing of histogram (we can use dynamic reconfigure for tuning now)
- Moved code to cpp file instead of header
- Option to configure whether to override the range to NaN
- Option to configure whether to override the intensity values to 0 (not intense) and 1 (intense)

_This refactor is backwards compatible so it would not break things for running configurations. Except for the API/ABI stability._