### PR TITLE
Use filters package from debs in CI

### DIFF
--- a/.github/workflows/ros2_ci.yml
+++ b/.github/workflows/ros2_ci.yml
@@ -33,10 +33,6 @@ jobs:
       with:
         path: src/laser_filters
 
-    # We need this from source until the next release fixes some bugs.
-    - name: Clone filters repo
-      run: git clone https://github.com/ros/filters src/filters -b ${{ matrix.filters_branch }}
-
     - name: Install dependencies
       run: rosdep update && apt-get update && rosdep install --from-path . -i -y --rosdistro ${{ matrix.rosdistro }}
 


### PR DESCRIPTION
Using it from source was a temporary workaround until some upstream
fixes were released.