### PR TITLE
change access specifiers for wrappers

### DIFF
--- a/include/laser_filters/box_filter.h
+++ b/include/laser_filters/box_filter.h
@@ -72,7 +72,7 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::LaserScan>
       const sensor_msgs::LaserScan& input_scan,
       sensor_msgs::LaserScan& filtered_scan);
 
-  private:
+  protected:
     bool inBox(tf::Point &point);
     std::string box_frame_;
     laser_geometry::LaserProjection projector_;

--- a/include/laser_filters/point_cloud_footprint_filter.h
+++ b/include/laser_filters/point_cloud_footprint_filter.h
@@ -122,7 +122,7 @@ public:
     return true;
   }
 
-private:
+protected:
   tf::TransformListener tf_;
   laser_geometry::LaserProjection projector_;
   double inscribed_radius_;


### PR DESCRIPTION
changing access specifier to `protected` (instead of `private`) so we can derive from base and change parameters dynamically with wrappers
