### PR TITLE
Fix compiler warnings

### DIFF
--- a/include/laser_filters/angular_bounds_filter.h
+++ b/include/laser_filters/angular_bounds_filter.h
@@ -37,7 +37,7 @@
 #ifndef LASER_SCAN_ANGULAR_BOUNDS_FILTER_H
 #define LASER_SCAN_ANGULAR_BOUNDS_FILTER_H
 
-#include <filters/filter_base.h>
+#include <filters/filter_base.hpp>
 #include <sensor_msgs/LaserScan.h>
 
 namespace laser_filters

--- a/include/laser_filters/angular_bounds_filter_in_place.h
+++ b/include/laser_filters/angular_bounds_filter_in_place.h
@@ -37,7 +37,7 @@
 #ifndef LASER_SCAN_ANGULAR_BOUNDS_FILTER_IN_PLACE_H
 #define LASER_SCAN_ANGULAR_BOUNDS_FILTER_IN_PLACE_H
 
-#include <filters/filter_base.h>
+#include <filters/filter_base.hpp>
 #include <sensor_msgs/LaserScan.h>
 
 namespace laser_filters

--- a/include/laser_filters/array_filter.h
+++ b/include/laser_filters/array_filter.h
@@ -38,9 +38,9 @@
 #include "boost/scoped_ptr.hpp"
 #include "sensor_msgs/LaserScan.h"
 
-#include "filters/median.h"
-#include "filters/mean.h"
-#include "filters/filter_chain.h"
+#include <filters/median.hpp>
+#include <filters/mean.hpp>
+#include <filters/filter_chain.hpp>
 #include "boost/thread/mutex.hpp"
 
 namespace laser_filters{

--- a/include/laser_filters/box_filter.h
+++ b/include/laser_filters/box_filter.h
@@ -47,7 +47,7 @@
 #ifndef BOXFILTER_H
 #define BOXFILTER_H
 
-#include <filters/filter_base.h>
+#include <filters/filter_base.hpp>
 
 #include <sensor_msgs/LaserScan.h>
 #include <sensor_msgs/point_cloud_conversion.h>

--- a/include/laser_filters/footprint_filter.h
+++ b/include/laser_filters/footprint_filter.h
@@ -42,7 +42,7 @@ This is useful for ground plane extraction
 **/
 
 
-#include "filters/filter_base.h"
+#include <filters/filter_base.hpp>
 #include "sensor_msgs/LaserScan.h"
 #include "tf/transform_listener.h"
 #include "sensor_msgs/PointCloud.h"

--- a/include/laser_filters/intensity_filter.h
+++ b/include/laser_filters/intensity_filter.h
@@ -39,7 +39,7 @@
 #pragma once
 
 #include <dynamic_reconfigure/server.h>
-#include <filters/filter_base.h>
+#include <filters/filter_base.hpp>
 #include <laser_filters/IntensityFilterConfig.h>
 #include <sensor_msgs/LaserScan.h>
 

--- a/include/laser_filters/interpolation_filter.h
+++ b/include/laser_filters/interpolation_filter.h
@@ -41,7 +41,7 @@
 **/
 
 
-#include "filters/filter_base.h"
+#include <filters/filter_base.hpp>
 #include "sensor_msgs/LaserScan.h"
 
 namespace laser_filters

--- a/include/laser_filters/median_filter.h
+++ b/include/laser_filters/median_filter.h
@@ -38,9 +38,9 @@
 #include "boost/scoped_ptr.hpp"
 #include "sensor_msgs/LaserScan.h"
 
-#include "filters/median.h"
-#include "filters/mean.h"
-#include "filters/filter_chain.h"
+#include <filters/median.hpp>
+#include <filters/mean.hpp>
+#include <filters/filter_chain.hpp>
 #include "boost/thread/mutex.hpp"
 
 namespace laser_filters{

--- a/include/laser_filters/point_cloud_footprint_filter.h
+++ b/include/laser_filters/point_cloud_footprint_filter.h
@@ -42,7 +42,7 @@ This is useful for ground plane extraction
 **/
 
 #include "laser_geometry/laser_geometry.h"
-#include "filters/filter_base.h"
+#include <filters/filter_base.hpp>
 #include "tf/transform_listener.h"
 #include "sensor_msgs/PointCloud.h"
 #include "ros/ros.h"

--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -43,7 +43,7 @@
 #ifndef POLYGON_FILTER_H
 #define POLYGON_FILTER_H
 
-#include <filters/filter_base.h>
+#include <filters/filter_base.hpp>
 
 #include <sensor_msgs/LaserScan.h>
 #include <sensor_msgs/point_cloud_conversion.h>

--- a/include/laser_filters/range_filter.h
+++ b/include/laser_filters/range_filter.h
@@ -42,7 +42,7 @@
 
 #include <dynamic_reconfigure/server.h>
 #include <laser_filters/RangeFilterConfig.h>
-#include "filters/filter_base.h"
+#include <filters/filter_base.hpp>
 #include "sensor_msgs/LaserScan.h"
 
 namespace laser_filters

--- a/include/laser_filters/scan_blob_filter.h
+++ b/include/laser_filters/scan_blob_filter.h
@@ -39,7 +39,7 @@
 
 #include <set>
 
-#include "filters/filter_base.h"
+#include <filters/filter_base.hpp>
 #include <sensor_msgs/LaserScan.h>
 #include "angles/angles.h"
 

--- a/include/laser_filters/scan_mask_filter.h
+++ b/include/laser_filters/scan_mask_filter.h
@@ -40,7 +40,7 @@
 **/
 
 
-#include "filters/filter_base.h"
+#include <filters/filter_base.hpp>
 #include "sensor_msgs/LaserScan.h"
 
 #include <XmlRpcException.h>

--- a/include/laser_filters/scan_shadows_filter.h
+++ b/include/laser_filters/scan_shadows_filter.h
@@ -39,7 +39,7 @@
 
 #include <set>
 
-#include "filters/filter_base.h"
+#include <filters/filter_base.hpp>
 #include "laser_filters/scan_shadow_detector.h"
 #include <sensor_msgs/LaserScan.h>
 #include <angles/angles.h>

--- a/include/laser_filters/sector_filter.h
+++ b/include/laser_filters/sector_filter.h
@@ -35,7 +35,7 @@
 #include <dynamic_reconfigure/server.h>
 #include <laser_filters/SectorFilterConfig.h>
 
-#include <filters/filter_base.h>
+#include <filters/filter_base.hpp>
 #include <sensor_msgs/LaserScan.h>
 
 namespace laser_filters

--- a/include/laser_filters/speckle_filter.h
+++ b/include/laser_filters/speckle_filter.h
@@ -41,7 +41,7 @@
 #define SPECKLE_FILTER_H
 
 #include <dynamic_reconfigure/server.h>
-#include <filters/filter_base.h>
+#include <filters/filter_base.hpp>
 #include <laser_filters/SpeckleFilterConfig.h>
 #include <sensor_msgs/LaserScan.h>
 

--- a/src/generic_laser_filter_node.cpp
+++ b/src/generic_laser_filter_node.cpp
@@ -33,7 +33,7 @@
 #include "message_filters/subscriber.h"
 #include "tf/message_filter.h"
 #include "tf/transform_listener.h"
-#include "filters/filter_chain.h"
+#include <filters/filter_chain.hpp>
 
 class GenericLaserScanFilterNode
 {

--- a/src/laser_scan_filters.cpp
+++ b/src/laser_scan_filters.cpp
@@ -43,7 +43,7 @@
 #include "laser_filters/scan_blob_filter.h"
 #include "laser_filters/sector_filter.h"
 #include "sensor_msgs/LaserScan.h"
-#include "filters/filter_base.h"
+#include <filters/filter_base.hpp>
 
 #include "pluginlib/class_list_macros.h"
 

--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -49,7 +49,7 @@
 #include "message_filters/subscriber.h"
 
 //Filters
-#include "filters/filter_chain.h"
+#include <filters/filter_chain.hpp>
 
 #if BUILDING_NODELET
 #include <nodelet/nodelet.h>

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -33,7 +33,7 @@
 #include "message_filters/subscriber.h"
 #include "tf/message_filter.h"
 #include "tf/transform_listener.h"
-#include "filters/filter_chain.h"
+#include <filters/filter_chain.hpp>
 
 class ScanToScanFilterChain
 {

--- a/src/speckle_filter.cpp
+++ b/src/speckle_filter.cpp
@@ -79,7 +79,7 @@ bool LaserScanSpeckleFilter::update(const sensor_msgs::LaserScan& input_scan, se
   /*Check if range size is big enough to use the filter window */
   if (output_scan.ranges.size() <= config_.filter_window + 1)
   {
-    ROS_ERROR("Scan ranges size is too small: size = %i", output_scan.ranges.size());
+    ROS_ERROR("Scan ranges size is too small: size = %ld", output_scan.ranges.size());
     return false;
   }
 

--- a/test/test_scan_filter_chain.cpp
+++ b/test/test_scan_filter_chain.cpp
@@ -28,7 +28,7 @@
  */
 
 #include <gtest/gtest.h>
-#include <filters/filter_chain.h>
+#include <filters/filter_chain.hpp>
 #include <ros/ros.h>
 #include "sensor_msgs/LaserScan.h"
 #include <pluginlib/class_loader.h>


### PR DESCRIPTION
Fix all compiler warnings.

Fixed following warnings concerning filters header file includes:
`warning Including header <filters/filter_base.h> is deprecated, include <filters/filter_base.hpp> instead. [-Wcpp]
`
Also fixed format warning in speckle_filter.cpp:
`warning: format ‘%i’ expects argument of type ‘int’, but argument 8 has type ‘std::vector<float>::size_type’ {aka ‘long unsigned int’} [-Wformat=]`

Btw, this is the first in a series of intended PRs. The following ones will include additional unit tests and performance improvements.