### PR TITLE
Revert "Use filters from source on CI"

### DIFF
--- a/.github/workflows/ros2_ci.yml
+++ b/.github/workflows/ros2_ci.yml
@@ -10,13 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        include:
-          - rosdistro: foxy
-            filters_branch: foxy
-          - rosdistro: galactic
-            filters_branch: ros2
-          - rosdistro: rolling
-            filters_branch: ros2
+        rosdistro: [foxy, galactic, rolling]
 
     runs-on: ubuntu-latest
 
@@ -32,10 +26,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         path: src/laser_filters
-
-    # We need this from source until the next release fixes some bugs.
-    - name: Clone filters repo
-      run: git clone https://github.com/ros/filters src/filters -b ${{ matrix.filters_branch }}
 
     - name: Install dependencies
       run: rosdep update && apt-get update && rosdep install --from-path . -i -y --rosdistro ${{ matrix.rosdistro }}


### PR DESCRIPTION
This needs to pass on CI before we can release laser_filters to galactic and rolling.

This reverts commit 44d0e4c5c392ee8dde762782a6cf0220be3682cb.