### PR TITLE
Use catkin_make to build and run tests on CI

### DIFF
--- a/.github/workflows/ros1_ci.yml
+++ b/.github/workflows/ros1_ci.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        path: src/
+        path: src/laser_filters
 
     - name: Build and run tests
       run: . /opt/ros/${{ matrix.rosdistro }}/setup.sh && src/laser_filters/ci.sh

--- a/.github/workflows/ros1_ci.yml
+++ b/.github/workflows/ros1_ci.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        path: src/
 
     - name: Build and run tests
       run: . /opt/ros/${{ matrix.rosdistro }}/setup.sh && ./ci.sh

--- a/.github/workflows/ros1_ci.yml
+++ b/.github/workflows/ros1_ci.yml
@@ -26,5 +26,5 @@ jobs:
         path: src/
 
     - name: Build and run tests
-      run: . /opt/ros/${{ matrix.rosdistro }}/setup.sh && ./ci.sh
+      run: . /opt/ros/${{ matrix.rosdistro }}/setup.sh && src/laser_filters/ci.sh
 

--- a/ci.sh
+++ b/ci.sh
@@ -1,22 +1,16 @@
 #!/bin/bash
+#
+# Run this script from the root of your catkin workspace.
+#
 
 # Exit with any error.
 set -e
 
-# Should be run from the root directory of the repo.
-BUILD_DIR=build
-
-mkdir -p ${BUILD_DIR}
-(cd ${BUILD_DIR} && cmake .. -DCATKIN_ENABLE_TESTING=1)
-
 # Build.
-make -C ${BUILD_DIR}
+catkin_make -DCATKIN_ENABLE_TESTING=1
 
-# Build the tests.
-make -C ${BUILD_DIR} tests
-
-# Run the tests.
-make -C ${BUILD_DIR} test
+# Run tests.
+catkin_make run_tests
 
 # Summarize test results (also sets the exit status for the script)
 catkin_test_results


### PR DESCRIPTION
Using cmake directly wasn't handling the LD_LIBRARY_PATH correctly when
running tests, causing them to use the version of the laser_filters
library from /opt/ros/... instead of the one compiled from source.