### PR TITLE
Speed up shadow filter

### DIFF
--- a/include/laser_filters/scan_shadow_detector.h
+++ b/include/laser_filters/scan_shadow_detector.h
@@ -46,18 +46,15 @@ namespace laser_filters
 class ScanShadowDetector
 {
 public:
+  friend class ScanShadowsFilter;
   float min_angle_tan_, max_angle_tan_;  // Filter angle thresholds
 
-  void configure(const float min_angle, const float max_angle, const int window);
-  void prepareForInput(const float angle_increment);
-  bool isShadow(const float r1, const float r2, const int angle_index);
+  void configure(const float min_angle, const float max_angle);
+  bool isShadow(const float r1, const float r2, const float included_angle);
 
   ~ScanShadowDetector();
 private:
-  int window_;
-  float angle_increment_;
-  std::vector<float> sin_map_;
-  std::vector<float> cos_map_;
+  bool isShadow(float r1, float r2, float included_angle_sin, float included_angle_cos);
 };
 }
 

--- a/include/laser_filters/scan_shadow_detector.h
+++ b/include/laser_filters/scan_shadow_detector.h
@@ -39,6 +39,8 @@
 #ifndef SCAN_SHADOW_DETECTOR_H
 #define SCAN_SHADOW_DETECTOR_H
 
+#include <vector>
+
 namespace laser_filters
 {
 class ScanShadowDetector
@@ -54,10 +56,8 @@ public:
 private:
   int window_;
   float angle_increment_;
-  float *sin_map_ = nullptr;
-  float *cos_map_ = nullptr;
-  float *shifted_sin_map_;
-  float *shifted_cos_map_;
+  std::vector<float> sin_map_;
+  std::vector<float> cos_map_;
 };
 }
 

--- a/include/laser_filters/scan_shadow_detector.h
+++ b/include/laser_filters/scan_shadow_detector.h
@@ -39,8 +39,6 @@
 #ifndef SCAN_SHADOW_DETECTOR_H
 #define SCAN_SHADOW_DETECTOR_H
 
-#include <cstddef>
-
 namespace laser_filters
 {
 class ScanShadowDetector
@@ -49,18 +47,17 @@ public:
   float min_angle_tan_, max_angle_tan_;  // Filter angle thresholds
 
   void configure(const float min_angle, const float max_angle, const int window);
-  bool isShadow(const float r1, const float r2, const int angle_index, const float angle_increment);
+  void prepareForInput(const float angle_increment);
+  bool isShadow(const float r1, const float r2, const int angle_index);
 
   ~ScanShadowDetector();
 private:
   int window_;
   float angle_increment_;
-  float *sin_map_ = NULL;
-  float *cos_map_ = NULL;
+  float *sin_map_ = nullptr;
+  float *cos_map_ = nullptr;
   float *shifted_sin_map_;
   float *shifted_cos_map_;
-
-  void updateAngleMap(const float angle_increment);
 };
 }
 

--- a/include/laser_filters/scan_shadow_detector.h
+++ b/include/laser_filters/scan_shadow_detector.h
@@ -46,8 +46,19 @@ class ScanShadowDetector
 public:
   float min_angle_tan_, max_angle_tan_;  // Filter angle thresholds
 
-  void configure(const float min_angle, const float max_angle);
-  bool isShadow(const float r1, const float r2, const float included_angle);
+  void configure(const float min_angle, const float max_angle, const int window);
+  bool isShadow(const float r1, const float r2, const int angle_index, const float angle_increment);
+
+  ~ScanShadowDetector();
+private:
+  int window_;
+  float angle_increment_;
+  float *sin_map_ = NULL;
+  float *cos_map_ = NULL;
+  float *shifted_sin_map_;
+  float *shifted_cos_map_;
+
+  void updateAngleMap(const float angle_increment);
 };
 }
 

--- a/include/laser_filters/scan_shadow_detector.h
+++ b/include/laser_filters/scan_shadow_detector.h
@@ -50,11 +50,25 @@ public:
   float min_angle_tan_, max_angle_tan_;  // Filter angle thresholds
 
   void configure(const float min_angle, const float max_angle);
+
+  /** \brief Check if the point is a shadow of another point within one laser scan.
+   * \param r1 the distance to the first point
+   * \param r2 the distance to the second point
+   * \param included_angle the angle between laser scans for these two points
+   */
   bool isShadow(const float r1, const float r2, const float included_angle);
 
-  ~ScanShadowDetector();
-private:
+  /** \brief Check if the point is a shadow of another point within one laser scan.
+   * Use this method instead of the version without the extra parameters to avoid
+   * computing sin and cos of the angle on every execution.
+   * \param r1 the distance to the first point
+   * \param r2 the distance to the second point
+   * \param included_angle_sin the sine of an angle between laser scans for these two points
+   * \param included_angle_cos the cosine of an angle between laser scans for these two points
+   */
   bool isShadow(float r1, float r2, float included_angle_sin, float included_angle_cos);
+
+  ~ScanShadowDetector();
 };
 }
 

--- a/include/laser_filters/scan_shadow_detector.h
+++ b/include/laser_filters/scan_shadow_detector.h
@@ -39,6 +39,8 @@
 #ifndef SCAN_SHADOW_DETECTOR_H
 #define SCAN_SHADOW_DETECTOR_H
 
+#include <cstddef>
+
 namespace laser_filters
 {
 class ScanShadowDetector

--- a/include/laser_filters/scan_shadow_detector.h
+++ b/include/laser_filters/scan_shadow_detector.h
@@ -46,7 +46,6 @@ namespace laser_filters
 class ScanShadowDetector
 {
 public:
-  friend class ScanShadowsFilter;
   float min_angle_tan_, max_angle_tan_;  // Filter angle thresholds
 
   void configure(const float min_angle, const float max_angle);
@@ -67,8 +66,6 @@ public:
    * \param included_angle_cos the cosine of an angle between laser scans for these two points
    */
   bool isShadow(float r1, float r2, float included_angle_sin, float included_angle_cos);
-
-  ~ScanShadowDetector();
 };
 }
 

--- a/include/laser_filters/scan_shadows_filter.h
+++ b/include/laser_filters/scan_shadows_filter.h
@@ -76,6 +76,12 @@ public:
    * \param scan_out the output LaserScan message
    */
   bool update(const sensor_msgs::LaserScan& scan_in, sensor_msgs::LaserScan& scan_out);
+private:
+  float angle_increment_;
+  std::vector<float> sin_map_;
+  std::vector<float> cos_map_;
+  
+  void prepareForInput(const float angle_increment);
 };
 }
 

--- a/src/scan_shadow_detector.cpp
+++ b/src/scan_shadow_detector.cpp
@@ -67,11 +67,11 @@ namespace laser_filters
 
   void ScanShadowDetector::prepareForInput(const float angle_increment) {
     if (angle_increment_ != angle_increment) {
-      ROS_DEBUG ("[projectLaser] No precomputed map given. Computing one.");
+      ROS_DEBUG ("[ScanShadowDetector] No precomputed map given. Computing one.");
       angle_increment_ = angle_increment;
 
       float included_angle = -window_ * angle_increment;
-      for (int i = -window_; i < window_ + 1; ++i) {
+      for (int i = -window_; i <= window_; ++i) {
         shifted_sin_map_[i] = fabs(sinf(included_angle));
         shifted_cos_map_[i] = cosf(included_angle);
         included_angle += angle_increment;

--- a/src/scan_shadow_detector.cpp
+++ b/src/scan_shadow_detector.cpp
@@ -78,8 +78,4 @@ namespace laser_filters
 
     return false;
   }
-
-  ScanShadowDetector::~ScanShadowDetector()
-  {
-  }
 }

--- a/src/scan_shadow_detector.cpp
+++ b/src/scan_shadow_detector.cpp
@@ -48,7 +48,7 @@ namespace laser_filters
     max_angle_tan_ = tanf(max_angle);
     window_ = window;
     angle_increment_ = 0;
-    if (sin_map_ != NULL)
+    if (sin_map_ != nullptr)
     {
       delete [] sin_map_;
       delete [] cos_map_;
@@ -65,24 +65,22 @@ namespace laser_filters
       max_angle_tan_ = -max_angle_tan_;
   }
 
-  void ScanShadowDetector::updateAngleMap(const float angle_increment) {
-    ROS_DEBUG ("[projectLaser] No precomputed map given. Computing one.");
-    angle_increment_ = angle_increment;
+  void ScanShadowDetector::prepareForInput(const float angle_increment) {
+    if (angle_increment_ != angle_increment) {
+      ROS_DEBUG ("[projectLaser] No precomputed map given. Computing one.");
+      angle_increment_ = angle_increment;
 
-    float included_angle = -window_ * angle_increment;
-    for (int i = -window_; i < window_ + 1; ++i) {
-      shifted_sin_map_[i] = fabs(sinf(included_angle));
-      shifted_cos_map_[i] = cosf(included_angle);
-      included_angle += angle_increment;
+      float included_angle = -window_ * angle_increment;
+      for (int i = -window_; i < window_ + 1; ++i) {
+        shifted_sin_map_[i] = fabs(sinf(included_angle));
+        shifted_cos_map_[i] = cosf(included_angle);
+        included_angle += angle_increment;
+      }
     }
   }
 
-  bool ScanShadowDetector::isShadow(const float r1, const float r2, const int angle_index, const float angle_increment)
+  bool ScanShadowDetector::isShadow(const float r1, const float r2, const int angle_index)
   {
-    if (angle_increment_ != angle_increment) {
-      updateAngleMap(angle_increment);
-    }
-
     const float perpendicular_y_ = r2 * shifted_sin_map_[angle_index];
     const float perpendicular_x_ = r1 - r2 * shifted_cos_map_[angle_index];
     const float perpendicular_tan_ = perpendicular_y_ / perpendicular_x_;
@@ -92,7 +90,7 @@ namespace laser_filters
 
   ScanShadowDetector::~ScanShadowDetector()
   {
-    if (sin_map_ != NULL)
+    if (sin_map_ != nullptr)
     {
       delete [] sin_map_;
       delete [] cos_map_;

--- a/src/scan_shadows_filter.cpp
+++ b/src/scan_shadows_filter.cpp
@@ -132,14 +132,14 @@ bool ScanShadowsFilter::update(const sensor_msgs::LaserScan& scan_in, sensor_msg
     scan_out = scan_in;
 
     int size = scan_in.ranges.size();
-    int maxY;
-    int maxNeighbors;
+    int max_y;
+    int max_neighbors;
     shadow_detector_.prepareForInput(scan_in.angle_increment);
     // For each point in the current line scan
     for (int i = 0; i < size; i++)
     {
-      maxY = std::min<int>(size - i, window_ + 1);
-      for (int y = std::max<int>(-i, -window_); y < maxY; y++)
+      max_y = std::min<int>(size - i, window_ + 1);
+      for (int y = std::max<int>(-i, -window_); y < max_y; y++)
       {
         if (y == 0)
         {
@@ -149,8 +149,8 @@ bool ScanShadowsFilter::update(const sensor_msgs::LaserScan& scan_in, sensor_msg
         if (shadow_detector_.isShadow(
                 scan_in.ranges[i], scan_in.ranges[i + y], y))
         {
-          maxNeighbors = std::min<int>(i + neighbors_, size - 1);
-          for (int index = std::max<int>(i - neighbors_, 0); index <= maxNeighbors; index++)
+          max_neighbors = std::min<int>(i + neighbors_, size - 1);
+          for (int index = std::max<int>(i - neighbors_, 0); index <= max_neighbors; index++)
           {
             if (scan_in.ranges[i] < scan_in.ranges[index])
             {  // delete neighbor if they are farther away (note not self)

--- a/src/scan_shadows_filter.cpp
+++ b/src/scan_shadows_filter.cpp
@@ -134,6 +134,7 @@ bool ScanShadowsFilter::update(const sensor_msgs::LaserScan& scan_in, sensor_msg
     int size = scan_in.ranges.size();
     int maxY;
     int maxNeighbors;
+    shadow_detector_.prepareForInput(scan_in.angle_increment);
     // For each point in the current line scan
     for (int i = 0; i < size; i++)
     {
@@ -146,7 +147,7 @@ bool ScanShadowsFilter::update(const sensor_msgs::LaserScan& scan_in, sensor_msg
         }
 
         if (shadow_detector_.isShadow(
-                scan_in.ranges[i], scan_in.ranges[i + y], y, scan_in.angle_increment))
+                scan_in.ranges[i], scan_in.ranges[i + y], y))
         {
           maxNeighbors = std::min<int>(i + neighbors_, size - 1);
           for (int index = std::max<int>(i - neighbors_, 0); index <= maxNeighbors; index++)

--- a/test/test_scan_shadows_filter.cpp
+++ b/test/test_scan_shadows_filter.cpp
@@ -5,7 +5,7 @@
 #include "sensor_msgs/LaserScan.h"
 
 sensor_msgs::LaserScan create_message(
-    float ranges[], int num_beams, float angle_limit = M_PI
+    float ranges[], int num_beams
 ) {
     sensor_msgs::LaserScan msg;
 
@@ -14,8 +14,8 @@ sensor_msgs::LaserScan create_message(
     msg.header.stamp = ros::Time::now();
     msg.header.frame_id = "laser";
     // Use a small beam so that angle_increment remains small (realistic) also with few points
-    msg.angle_min = -angle_limit / 12;
-    msg.angle_max = angle_limit / 12;
+    msg.angle_min = -M_PI / 12;
+    msg.angle_max = M_PI / 12;
     msg.angle_increment = (msg.angle_max - msg.angle_min) / (num_beams - 1);
     msg.time_increment = 0.1 / num_beams;
     msg.scan_time = 0.1;

--- a/test/test_shadow_detector.cpp
+++ b/test/test_shadow_detector.cpp
@@ -64,8 +64,7 @@ TEST(ScanShadowDetector, ShadowDetectionGeometry)
     for (float max_angle = 90.0; max_angle <= 180; max_angle += 5.0)
     {
       laser_filters::ScanShadowDetector detector;
-      detector.configure(angles::from_degrees(min_angle), angles::from_degrees(max_angle), window);
-      detector.prepareForInput(angle_increment);
+      detector.configure(angles::from_degrees(min_angle), angles::from_degrees(max_angle));
 
       for (float r1 = 0.1; r1 < 1.0; r1 += 0.1)
       {
@@ -78,7 +77,7 @@ TEST(ScanShadowDetector, ShadowDetectionGeometry)
               
             // Compare with original ScanShadowsFilter implementation
             EXPECT_EQ(
-                detector.isShadow(r1, r2, inc),
+                detector.isShadow(r1, r2, inc * angle_increment),
                 isShadowPureImpl(r1, r2, inc * angle_increment, min_angle, max_angle));
           }
         }

--- a/test/test_shadow_detector.cpp
+++ b/test/test_shadow_detector.cpp
@@ -58,20 +58,24 @@ bool isShadowPureImpl(const float r1, const float r2, const float included_angle
 TEST(ScanShadowDetector, ShadowDetectionGeometry)
 {
   const float angle_increment = 0.02;
+  const int window = 5;
   for (float min_angle = 90.0; min_angle >= 0.0; min_angle -= 5.0)
   {
     for (float max_angle = 90.0; max_angle <= 180; max_angle += 5.0)
     {
       laser_filters::ScanShadowDetector detector;
-      detector.configure(angles::from_degrees(min_angle), angles::from_degrees(max_angle), 5);
+      detector.configure(angles::from_degrees(min_angle), angles::from_degrees(max_angle), window);
       detector.prepareForInput(angle_increment);
 
       for (float r1 = 0.1; r1 < 1.0; r1 += 0.1)
       {
         for (float r2 = 0.1; r2 < 1.0; r2 += 0.1)
         {
-          for (int inc = 1; inc < 6; ++inc)
+          for (int inc = -window; inc <= window; ++inc)
           {
+            if (inc == 0)
+              continue;
+              
             // Compare with original ScanShadowsFilter implementation
             EXPECT_EQ(
                 detector.isShadow(r1, r2, inc),

--- a/test/test_shadow_detector.cpp
+++ b/test/test_shadow_detector.cpp
@@ -62,18 +62,18 @@ TEST(ScanShadowDetector, ShadowDetectionGeometry)
     for (float max_angle = 90.0; max_angle <= 180; max_angle += 5.0)
     {
       laser_filters::ScanShadowDetector detector;
-      detector.configure(angles::from_degrees(min_angle), angles::from_degrees(max_angle));
+      detector.configure(angles::from_degrees(min_angle), angles::from_degrees(max_angle), 5);
 
       for (float r1 = 0.1; r1 < 1.0; r1 += 0.1)
       {
         for (float r2 = 0.1; r2 < 1.0; r2 += 0.1)
         {
-          for (float inc = 0.01; inc < 0.1; inc += 0.02)
+          for (int inc = 1; inc < 6; ++inc)
           {
             // Compare with original ScanShadowsFilter implementation
             EXPECT_EQ(
-                detector.isShadow(r1, r2, inc),
-                isShadowPureImpl(r1, r2, inc, min_angle, max_angle));
+                detector.isShadow(r1, r2, inc, 0.02),
+                isShadowPureImpl(r1, r2, inc * 0.02, min_angle, max_angle));
           }
         }
       }

--- a/test/test_shadow_detector.cpp
+++ b/test/test_shadow_detector.cpp
@@ -38,6 +38,7 @@
 
 #include <gtest/gtest.h>
 #include <angles/angles.h>
+#include <math.h>
 
 #include "laser_filters/scan_shadow_detector.h"
 
@@ -74,11 +75,18 @@ TEST(ScanShadowDetector, ShadowDetectionGeometry)
           {
             if (inc == 0)
               continue;
+
+            float angle = inc * angle_increment;
               
             // Compare with original ScanShadowsFilter implementation
             EXPECT_EQ(
-                detector.isShadow(r1, r2, inc * angle_increment),
-                isShadowPureImpl(r1, r2, inc * angle_increment, min_angle, max_angle));
+                detector.isShadow(r1, r2, angle),
+                isShadowPureImpl(r1, r2, angle, min_angle, max_angle));
+              
+            // Compare with original ScanShadowsFilter implementation
+            EXPECT_EQ(
+                detector.isShadow(r1, r2, sinf(angle), cosf(angle)),
+                isShadowPureImpl(r1, r2, angle, min_angle, max_angle));
           }
         }
       }

--- a/test/test_shadow_detector.cpp
+++ b/test/test_shadow_detector.cpp
@@ -57,12 +57,14 @@ bool isShadowPureImpl(const float r1, const float r2, const float included_angle
 
 TEST(ScanShadowDetector, ShadowDetectionGeometry)
 {
+  const float angle_increment = 0.02;
   for (float min_angle = 90.0; min_angle >= 0.0; min_angle -= 5.0)
   {
     for (float max_angle = 90.0; max_angle <= 180; max_angle += 5.0)
     {
       laser_filters::ScanShadowDetector detector;
       detector.configure(angles::from_degrees(min_angle), angles::from_degrees(max_angle), 5);
+      detector.prepareForInput(angle_increment);
 
       for (float r1 = 0.1; r1 < 1.0; r1 += 0.1)
       {
@@ -72,8 +74,8 @@ TEST(ScanShadowDetector, ShadowDetectionGeometry)
           {
             // Compare with original ScanShadowsFilter implementation
             EXPECT_EQ(
-                detector.isShadow(r1, r2, inc, 0.02),
-                isShadowPureImpl(r1, r2, inc * 0.02, min_angle, max_angle));
+                detector.isShadow(r1, r2, inc),
+                isShadowPureImpl(r1, r2, inc * angle_increment, min_angle, max_angle));
           }
         }
       }


### PR DESCRIPTION
Improve performance of scan shadow filter.

Changes:
- Instead of calculating sine/cosine each update, store (few) needed values in look-up tables and re-use those
- Remove use of set collection (and associated dynamic memory allocations) in update method
- Minor improvements to for-loop end criteria and checks inside loops

Together this results in speed-up of update method by more than factor three.

Added test to verify that lookup arrays is updated when needed.
Updated detector test to include negative angles (and more generally, match usage of detector in filter).