### PR TITLE
Add static polygon filter

### DIFF
--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -75,15 +75,12 @@ protected:
   geometry_msgs::Polygon polygon_;
   double polygon_padding_;
   bool invert_filter_;
+  std::shared_ptr<dynamic_reconfigure::Server<laser_filters::PolygonFilterConfig>> dyn_server_;
 
   virtual void reconfigureCB(laser_filters::PolygonFilterConfig& config, uint32_t level);
 
   // checks if points in polygon
   bool inPolygon(tf::Point& point) const;
-
-private:
-  // configuration
-  std::shared_ptr<dynamic_reconfigure::Server<laser_filters::PolygonFilterConfig>> dyn_server_;
 };
 
 class LaserScanPolygonFilter : public LaserScanPolygonFilterBase {

--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -76,7 +76,7 @@ protected:
   double polygon_padding_;
   bool invert_filter_;
 
-  void reconfigureCB(laser_filters::PolygonFilterConfig& config, uint32_t level);
+  virtual void reconfigureCB(laser_filters::PolygonFilterConfig& config, uint32_t level);
 
   // checks if points in polygon
   bool inPolygon(tf::Point& point) const;
@@ -88,6 +88,7 @@ private:
 
 class LaserScanPolygonFilter : public LaserScanPolygonFilterBase {
 public:
+  bool configure() override;
   bool update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& filtered_scan) override;
 
 private:
@@ -99,12 +100,18 @@ private:
 };
 
 /**
- * @brief This is a filter that removes points in a laser scan inside of a polygon
- * assuming that the transform between polygon and scanner remains static over the entire run.
+ * @brief This is a filter that removes points in a laser scan inside of a polygon.
+ * It assumes that the transform between the scanner and the robot base remains unchanged,
+ * i.e. the position and orientation of the laser filter should not change.
+ * A typical use case for this filter is to filter out parts of the robot body or load that it may carry.
  */
 class StaticLaserScanPolygonFilter : public LaserScanPolygonFilterBase {
 public:
+  bool configure() override;
   bool update(const sensor_msgs::LaserScan& input_scan, sensor_msgs::LaserScan& filtered_scan) override;
+  
+protected:
+  void reconfigureCB(laser_filters::PolygonFilterConfig& config, uint32_t level) override;
 
 private:
   Eigen::ArrayXXd co_sine_map_;

--- a/src/polygon_filter.cpp
+++ b/src/polygon_filter.cpp
@@ -464,7 +464,7 @@ bool StaticLaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_sc
   boost::recursive_mutex::scoped_lock lock(own_mutex_);
 
   if (!is_polygon_transformed_) {
-    tf::TransformListener transform_listener();
+    tf::TransformListener transform_listener;
 
     std::string error_msg;
     bool success = transform_listener.waitForTransform(

--- a/src/polygon_filter.cpp
+++ b/src/polygon_filter.cpp
@@ -464,8 +464,8 @@ bool StaticLaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_sc
   boost::recursive_mutex::scoped_lock lock(own_mutex_);
 
   if (!is_polygon_transformed_) {
-    tf::TransformListener tf();
-    bool success = tf.waitForTransform(
+    tf::TransformListener transform_listener();
+    bool success = transform_listener.waitForTransform(
         input_scan.header.frame_id, polygon_frame_,
         input_scan.header.stamp + ros::Duration().fromSec(input_scan.ranges.size() * input_scan.time_increment),
         ros::Duration(1.0), ros::Duration(0.01), &error_msg);
@@ -485,7 +485,7 @@ bool StaticLaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_sc
           input_scan.header.stamp + ros::Duration().fromSec(input_scan.ranges.size() * input_scan.time_increment),
           polygon_frame_);
         tf::Stamped<tf::Point> point_stamped_new;
-        tf_.transformPoint(input_scan.header.frame_id, point_stamped, point_stamped_new);
+        transform_listener.transformPoint(input_scan.header.frame_id, point_stamped, point_stamped_new);
         geometry_msgs::PointStamped result_point;
         tf::pointStampedTFToMsg(point_stamped_new, result_point);
         polygon_.points[i].x = result_point.point.x;

--- a/src/polygon_filter.cpp
+++ b/src/polygon_filter.cpp
@@ -465,6 +465,8 @@ bool StaticLaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_sc
 
   if (!is_polygon_transformed_) {
     tf::TransformListener transform_listener();
+
+    std::string error_msg;
     bool success = transform_listener.waitForTransform(
         input_scan.header.frame_id, polygon_frame_,
         input_scan.header.stamp + ros::Duration().fromSec(input_scan.ranges.size() * input_scan.time_increment),


### PR DESCRIPTION
This adds a variant of the existing polygon filter.

The new filter assumes that the transform from the robot's base to the laser filter is static, i.e. the position and orientation of the laser filter is fixed. This is typically the case. This assumption allows significantly lower CPU usage. First, it does not need to continuously listen to the active transform topic anymore. This ensures that laser filter chains for which there is no laser filter data (e.g. because they are temporarily disabled or are optional and not installed) consume no CPU. On our set-up, each dormant chain was still consuming 1% of CPU, which adds up if you have multiple chains. Second, the transform calculations can be removed from the update loop, as they only need to be performed once, during configuration.

I am not sure if the behavior of the old filter is required. If not, the new filter could replace the old one.
However, in order not to introduce any breaking changes, the new static filter is added alongside the old implementation. A common base class is added for code reuse.
