### PR TITLE
Register static polygon filter as plugin

### DIFF
--- a/laser_filters_plugins.xml
+++ b/laser_filters_plugins.xml
@@ -60,6 +60,12 @@
 	This is a filter that removes points in a laser scan inside of a polygon.
       </description>
     </class>
+      <class name="laser_filters/StaticLaserScanPolygonFilter" type="laser_filters::StaticLaserScanPolygonFilter"
+	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
+      <description>
+	This is a filter that removes points in a laser scan inside of a polygon static relative to robot base.
+      </description>
+    </class>
     <class name="laser_filters/LaserScanSpeckleFilter" type="laser_filters::LaserScanSpeckleFilter"
 	    base_class_type="filters::FilterBase<sensor_msgs::LaserScan>">
       <description>

--- a/src/laser_scan_filters.cpp
+++ b/src/laser_scan_filters.cpp
@@ -59,6 +59,7 @@ PLUGINLIB_EXPORT_CLASS(laser_filters::ScanShadowsFilter, filters::FilterBase<sen
 PLUGINLIB_EXPORT_CLASS(laser_filters::InterpolationFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanBoxFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanPolygonFilter, filters::FilterBase<sensor_msgs::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::StaticLaserScanPolygonFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanSpeckleFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanMaskFilter, filters::FilterBase<sensor_msgs::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::ScanBlobFilter, filters::FilterBase<sensor_msgs::LaserScan>)


### PR DESCRIPTION
PR #145 added a new filter, the static polygon filter.

However, it could not yet be used in launch files as it was not yet registered as plugin.
This PR fixes that.