### PR TITLE
Improve robustness of polygon fetch by static polygon filter

### DIFF
--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -43,7 +43,7 @@
 #ifndef POLYGON_FILTER_H
 #define POLYGON_FILTER_H
 
-#include <filters/filter_base.h>
+#include <filters/filter_base.hpp>
 
 #include <sensor_msgs/LaserScan.h>
 #include <sensor_msgs/point_cloud_conversion.h>

--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -113,6 +113,8 @@ protected:
   void reconfigureCB(laser_filters::PolygonFilterConfig& config, uint32_t level) override;
 
 private:
+  double transform_timeout_;
+
   Eigen::ArrayXXd co_sine_map_;
   float co_sine_map_angle_min_;
   float co_sine_map_angle_max_;

--- a/src/polygon_filter.cpp
+++ b/src/polygon_filter.cpp
@@ -299,7 +299,8 @@ bool LaserScanPolygonFilterBase::inPolygon(tf::Point& point) const {
   int i, j;
   bool c = false;
 
-  for (i = 0, j = polygon_.points.size() - 1; i < polygon_.points.size(); j = i++) {
+  for (i = 0, j = polygon_.points.size() - 1; i < polygon_.points.size(); j = i++)
+  {
     if ((polygon_.points.at(i).y > point.y() != (polygon_.points.at(j).y > point.y()) &&
          (point.x() < (polygon_.points[j].x - polygon_.points[i].x) * (point.y() - polygon_.points[i].y) /
                               (polygon_.points[j].y - polygon_.points[i].y) +
@@ -309,8 +310,10 @@ bool LaserScanPolygonFilterBase::inPolygon(tf::Point& point) const {
   return c;
 }
 
-void LaserScanPolygonFilterBase::publishPolygon() {
-  if (!is_polygon_published_) {
+void LaserScanPolygonFilterBase::publishPolygon()
+{
+  if (!is_polygon_published_)
+  {
     geometry_msgs::PolygonStamped polygon_stamped;
     polygon_stamped.header.frame_id = polygon_frame_;
     polygon_stamped.header.stamp = ros::Time::now();
@@ -320,7 +323,8 @@ void LaserScanPolygonFilterBase::publishPolygon() {
   }
 }
 
-void LaserScanPolygonFilterBase::reconfigureCB(laser_filters::PolygonFilterConfig& config, uint32_t level) {
+void LaserScanPolygonFilterBase::reconfigureCB(laser_filters::PolygonFilterConfig& config, uint32_t level)
+{
   invert_filter_ = config.invert;
   polygon_ = makePolygonFromString(config.polygon, polygon_);
   padPolygon(polygon_, config.polygon_padding);
@@ -328,7 +332,7 @@ void LaserScanPolygonFilterBase::reconfigureCB(laser_filters::PolygonFilterConfi
 }
 
 bool LaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_scan,
-                                                   sensor_msgs::LaserScan& output_scan)
+                                    sensor_msgs::LaserScan& output_scan)
 {
   boost::recursive_mutex::scoped_lock lock(own_mutex_);
 
@@ -423,7 +427,8 @@ bool StaticLaserScanPolygonFilter::configure()
   return LaserScanPolygonFilterBase::configure();
 }
 
-void StaticLaserScanPolygonFilter::checkCoSineMap(const sensor_msgs::LaserScan& scan_in) {
+void StaticLaserScanPolygonFilter::checkCoSineMap(const sensor_msgs::LaserScan& scan_in)
+{
   size_t n_pts = scan_in.ranges.size();
 
   if (
@@ -431,13 +436,14 @@ void StaticLaserScanPolygonFilter::checkCoSineMap(const sensor_msgs::LaserScan& 
     co_sine_map_angle_min_ != scan_in.angle_min ||
     co_sine_map_angle_max_ != scan_in.angle_max
   ) {
-    ROS_DEBUG ("[StaticLaserScanPolygonFilter] No precomputed map given. Computing one.");
+    ROS_DEBUG_NAMED("StaticLaserScanPolygonFilter", "No precomputed map given. Computing one.");
     co_sine_map_ = Eigen::ArrayXXd(n_pts, 2);
     co_sine_map_angle_min_ = scan_in.angle_min;
     co_sine_map_angle_max_ = scan_in.angle_max;
 
     // Spherical->Cartesian projection
-    for (size_t i = 0; i < n_pts; ++i) {
+    for (size_t i = 0; i < n_pts; ++i)
+    {
       co_sine_map_(i, 0) = cos(scan_in.angle_min + (double) i * scan_in.angle_increment);
       co_sine_map_(i, 1) = sin(scan_in.angle_min + (double) i * scan_in.angle_increment);
     }
@@ -451,7 +457,8 @@ void StaticLaserScanPolygonFilter::checkCoSineMap(const sensor_msgs::LaserScan& 
 // A pre-requisite for this to work is that the transform is static, i.e. the position and orientation of the laser with regard to
 // the base of the robot does not change.
 bool StaticLaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_scan,
-                                        sensor_msgs::LaserScan& output_scan) {
+                                          sensor_msgs::LaserScan& output_scan)
+{
   boost::recursive_mutex::scoped_lock lock(own_mutex_);
 
   publishPolygon();
@@ -460,8 +467,8 @@ bool StaticLaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_sc
     tf::TransformListener transform_listener;
 
     std::string error_msg;
-    ROS_DEBUG(
-      "[StaticLaserScanPolygonFilter] waitForTransform %s -> %s",
+    ROS_DEBUG_NAMED(
+      "StaticLaserScanPolygonFilter", "waitForTransform %s -> %s",
       polygon_frame_.c_str(), input_scan.header.frame_id.c_str()
     );
     bool success = transform_listener.waitForTransform(
@@ -472,17 +479,24 @@ bool StaticLaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_sc
       &error_msg
     );
 
-    if (!success) {
-      ROS_WARN("[StaticLaserScanPolygonFilter] Could not get transform, ignoring laser scan! %s", error_msg.c_str());
+    if (!success)
+    {
+      ROS_WARN_THROTTLE_NAMED(
+          1, "StaticLaserScanPolygonFilter",
+          "Could not get transform, ignoring laser scan! %s", error_msg.c_str()
+      );
       return false;
-    } else {
-      ROS_DEBUG("[StaticLaserScanPolygonFilter] obtained transform");
+    }
+    else
+    {
+      ROS_INFO_NAMED("StaticLaserScanPolygonFilter", "Obtained transform");
     }
 
     try {
       // Transform each point of polygon. This includes multiple type convertions because of transformPoint API requiring Stamped<Point>
       // which does not in turn expose coordinate values
-      for (int i = 0; i < polygon_.points.size(); ++i) {
+      for (int i = 0; i < polygon_.points.size(); ++i)
+      {
         tf::Point point(polygon_.points[i].x, polygon_.points[i].y, 0);
         tf::Stamped<tf::Point> point_stamped(point, ros::Time(), polygon_frame_);
         tf::Stamped<tf::Point> point_stamped_new;
@@ -495,8 +509,9 @@ bool StaticLaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_sc
 
       is_polygon_transformed_ = true;
     }
-    catch (tf::TransformException& ex) {
-      ROS_INFO("[StaticLaserScanPolygonFilter] Exception while transforming polygon");
+    catch (tf::TransformException& ex)
+    {
+      ROS_WARN_THROTTLE_NAMED(1, "StaticLaserScanPolygonFilter", "Exception while transforming polygon");
       return false;
     }
   }
@@ -507,14 +522,16 @@ bool StaticLaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_sc
   size_t i = 0;
   size_t i_max = input_scan.ranges.size();
 
-  while (i < i_max) {
+  while (i < i_max)
+  {
     float range = input_scan.ranges[i];
 
     float x = co_sine_map_(i, 0) * range;
     float y = co_sine_map_(i, 1) * range;
     tf::Point point(x, y, 0);
 
-    if (invert_filter_ != inPolygon(point)) {
+    if (invert_filter_ != inPolygon(point))
+    {
       output_scan.ranges[i] = std::numeric_limits<float>::quiet_NaN();
     }
 
@@ -524,7 +541,8 @@ bool StaticLaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_sc
   return true;
 }
 
-void StaticLaserScanPolygonFilter::reconfigureCB(laser_filters::PolygonFilterConfig& config, uint32_t level) {
+void StaticLaserScanPolygonFilter::reconfigureCB(laser_filters::PolygonFilterConfig& config, uint32_t level)
+{
   is_polygon_transformed_ = false;
   LaserScanPolygonFilterBase::reconfigureCB(config, level);
 }

--- a/src/polygon_filter.cpp
+++ b/src/polygon_filter.cpp
@@ -416,6 +416,10 @@ bool LaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_scan,
 bool StaticLaserScanPolygonFilter::configure()
 {
   is_polygon_transformed_ = false;
+
+  transform_timeout_ = 5; // Default
+  getParam("transform_timeout", transform_timeout_);
+
   return LaserScanPolygonFilterBase::configure();
 }
 
@@ -463,7 +467,7 @@ bool StaticLaserScanPolygonFilter::update(const sensor_msgs::LaserScan& input_sc
     bool success = transform_listener.waitForTransform(
       input_scan.header.frame_id, polygon_frame_,
       ros::Time(),       // No restrictions on transform time. It is static.
-      ros::Duration(60), // In a loaded system, it can take long for data to arrive
+      ros::Duration(transform_timeout_),
       ros::Duration(0),  // This setting has no effect
       &error_msg
     );


### PR DESCRIPTION
During integration tests using the new static polygon filter we faced problems with time outs when listening for the required transform.

This PR fixes that by, firstly, not putting restrictions on the time of the requested transform (it is static anyway), and secondly, increasing the hard-coded timeout limit to sixty seconds. This should suffice. In our testing it required at most ten seconds. 