### PR TITLE
Remove remaining uses of boost.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(BUILD_TESTING)
     ament_target_dependencies(${TEST_NAME} filters pluginlib rclcpp sensor_msgs)
     ament_add_test(
         ${TEST_NAME}
-        COMMAND 
+        COMMAND
             $<TARGET_FILE:${TEST_NAME}>
             --ros-args --params-file ${PROJECT_SOURCE_DIR}/test/${TEST_NAME}.yaml
             --gtest_output=xml:${RESULT_FILENAME}

--- a/include/laser_filters/array_filter.h
+++ b/include/laser_filters/array_filter.h
@@ -32,21 +32,19 @@
 
 #include <map>
 #include <iostream>
+#include <mutex>
 #include <sstream>
 
-#include "boost/thread/mutex.hpp"
-#include "boost/scoped_ptr.hpp"
 #include <sensor_msgs/msg/laser_scan.hpp>
 
 #include "filters/median.hpp"
 #include "filters/mean.hpp"
 #include "filters/filter_chain.hpp"
-#include "boost/thread/mutex.hpp"
 
 namespace laser_filters{
 
 /** \brief A class to provide median filtering of laser scans in time*/
-class LaserArrayFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan> 
+class LaserArrayFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan>
 {
 public:
   /** \brief Constructor
@@ -96,7 +94,7 @@ public:
       return false;
     }
 
-    boost::mutex::scoped_lock lock(data_lock);
+    std::lock_guard<std::mutex> lock(data_lock);
     scan_out = scan_in; ///Quickly pass through all data \todo don't copy data too
 
     if (scan_in.ranges.size() != num_ranges_) //Reallocating
@@ -122,7 +120,7 @@ private:
   rclcpp::Parameter range_config_;
   rclcpp::Parameter intensity_config_;
 
-  boost::mutex data_lock;                 /// Protection from multi threaded programs
+  std::mutex data_lock;                 /// Protection from multi threaded programs
   sensor_msgs::msg::LaserScan temp_scan_; /** \todo cache only shallow info not full scan */
 
   filters::MultiChannelFilterChain<float> *range_filter_;

--- a/include/laser_filters/median_filter.h
+++ b/include/laser_filters/median_filter.h
@@ -34,15 +34,11 @@
 #include <iostream>
 #include <sstream>
 
-#include "boost/thread/mutex.hpp"
-#include "boost/scoped_ptr.hpp"
-
 #include <sensor_msgs/msg/laser_scan.hpp>
 
 #include "filters/median.hpp"
 #include "filters/mean.hpp"
 #include "filters/filter_chain.hpp"
-#include "boost/thread/mutex.hpp"
 
 namespace laser_filters
 {
@@ -99,7 +95,7 @@ namespace laser_filters
         RCLCPP_ERROR(logging_interface_->get_logger(), "LaserMedianFilter not configured");
         return false;
       }
-      boost::mutex::scoped_lock lock(data_lock);
+      std::lock_guard<std::mutex> lock(data_lock);
       scan_out = scan_in; ///Quickly pass through all data \todo don't copy data too
 
       if (scan_in.ranges.size() != num_ranges_) //Reallocating
@@ -130,7 +126,7 @@ namespace laser_filters
     unsigned int filter_length_; ///How many scans to average over
     unsigned int num_ranges_;    /// How many data point are in each row
 
-    boost::mutex data_lock;                 /// Protection from multi threaded programs
+    std::mutex data_lock;                 /// Protection from multi threaded programs
     sensor_msgs::msg::LaserScan temp_scan_; /** \todo cache only shallow info not full scan */
 
     // rclcpp::parameter::ParameterVariant parameter_value_;

--- a/package.xml
+++ b/package.xml
@@ -13,17 +13,17 @@
 
   <build_depend>ament_cmake_auto</build_depend>
 
-  <depend>pluginlib</depend>
-  <depend>sensor_msgs</depend>
-  <depend>rclcpp</depend>
-  <depend>tf2</depend>
-  <depend>filters</depend>
-  <depend>message_filters</depend>
-  <depend>tf2_ros</depend>
-  <depend>laser_geometry</depend>
   <depend>angles</depend>
+  <depend>filters</depend>
+  <depend>laser_geometry</depend>
+  <depend>message_filters</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
-  
+  <depend>sensor_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+
   <test_depend>ament_cmake_gtest</test_depend>
 
   <export>


### PR DESCRIPTION
All of that functionality is now available in std:: .  Also, this
should fix the build on RHEL.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix #150 