### PR TITLE
Do not use "not" as it is not defined in MSVC

### DIFF
--- a/include/laser_filters/box_filter.h
+++ b/include/laser_filters/box_filter.h
@@ -89,7 +89,7 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserSca
 
       bool invert = false;
       getParam("invert", invert);
-      remove_box_points_ = not invert;
+      remove_box_points_ = !invert;
 
       if (!box_frame_set)
       {


### PR DESCRIPTION
Additionally, the symbols are also not `dllexport`'ed for Windows/MSVC.

I've fixed that by adding `set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS 1)`, but maybe you prefer manual visibility annotations?