### PR TITLE
Setting STATUS lvl to msgs reg. performance tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,10 +74,10 @@ add_dependencies(laser_scan_filters ${PROJECT_NAME}_gencfg)
 
 if (CATKIN_ENABLE_TESTING)
   if (CATKIN_ENABLE_PERFORMANCE_TESTING)
-    message("Enabling performance tests")
+    message(STATUS "Enabling performance tests")
     add_definitions(-DENABLE_PERFORMANCE)
   else()
-    message("Disabled performance tests")
+    message(STATUS "Disabled performance tests")
   endif()
 
   find_package(rostest)


### PR DESCRIPTION
Default level of CMake's Message is None/Notice, these are forwarded to stderr, triggering a warning in the build when using catkin build.

I'm not sure what the desired behaviour was, but IMO both messages should be on STATUS level or at least the one where the performance test is enabled.