### PR TITLE
Inconsistency between implementation and param description on intensity filter

### DIFF
--- a/cfg/IntensityFilter.cfg
+++ b/cfg/IntensityFilter.cfg
@@ -41,9 +41,9 @@ PACKAGE = "laser_filters"
 gen = ParameterGenerator()
 
 gen.add("lower_threshold", double_t, 0,
-        "Intensity values lower than this value will be filtered", 8000.0, 0, 100000.0)
+        "Intensity values lower equal than this value will be filtered. Use negative values for no lower bound filtering.", 8000.0, -1.0, 100000.0)
 gen.add("upper_threshold", double_t, 0,
-        "Intensity values greater than this value will be filtered", 100000.0, 0, 100000.0)
+        "Intensity values greater equal than this value will be filtered", 100000.0, 0, 100000.0)
 gen.add("invert", bool_t, 0, "A Boolean to invert the filter", False)
 
 gen.add("filter_override_range", bool_t, 0,

--- a/src/intensity_filter.cpp
+++ b/src/intensity_filter.cpp
@@ -73,8 +73,8 @@ bool LaserScanIntensityFilter::update(const sensor_msgs::LaserScan& input_scan, 
     float& range = filtered_scan.ranges[i];
     float& intensity = filtered_scan.intensities[i];
 
-    // Is this reading below our lower threshold?
-    // Is this reading above our upper threshold?
+    // Is this reading below or equal to our lower threshold?
+    // Is this reading above or equal to our upper threshold?
     bool filter = intensity <= config_.lower_threshold || intensity >= config_.upper_threshold;
     if (config_.invert)
     {


### PR DESCRIPTION
The "lower_threshold"-param of the intensity filter describes that "Intensity values lower than this value will be filtered", while the implementation filters for values "lower equal", see https://github.com/ros-perception/laser_filters/blob/noetic-devel/src/intensity_filter.cpp#L78

Our proposal would be to keep the implementation as is and to update the description. Further, we propose to allow a negative value as a lower bound on the "lower_threshold" to allow no filtering on the lower bound. With the current implementation we saw in simulation that laser measurements with zero intensity were filtered out as well, which is undesired.

As an alternative, we can keep the dynamic configuration as is, but make the implementation consistent by replacing the "<=" statements in the link above by "<".