### PR TITLE
Update scan_to_cloud_filter_chain.cpp

### DIFF
--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -41,6 +41,7 @@
 // TF
 #include <tf2_ros/transform_listener.h>
 #include "tf2_ros/message_filter.h"
+#include "tf2_ros/create_timer_ros.h"
 
 #include "message_filters/subscriber.h"
 
@@ -106,7 +107,12 @@ public:
     filter_.setTargetFrame(target_frame_);
     filter_.registerCallback(std::bind(&ScanToCloudFilterChain::scanCallback, this, std::placeholders::_1));
     filter_.setTolerance(std::chrono::duration<double>(tf_tolerance_));
-
+                                                           
+    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
+      nh_->get_node_base_interface(),
+      nh_->get_node_timers_interface());
+    buffer_.setCreateTimerInterface(timer_interface);
+                                                           
     sub_.subscribe(nh_, "scan", rmw_qos_profile_sensor_data);
 
     filter_.connectInput(sub_);


### PR DESCRIPTION
As of Eloquent, a timer interface is required for the tf buffer.  Otherwise a tf2_ros::CreateTimerInterfaceException is thrown.

https://docs.ros.org/en/galactic/Releases/Release-Eloquent-Elusor.html#tf2-buffer