### PR TITLE
ROS1 Nodelet Updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,12 +60,14 @@ target_link_libraries(laser_scan_filters ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 add_executable(scan_to_cloud_filter_chain src/scan_to_cloud_filter_chain.cpp)
 target_link_libraries(scan_to_cloud_filter_chain ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
-add_library(scan_to_cloud_filter_chain_nodelet src/scan_to_cloud_filter_chain.cpp)
-target_link_libraries(scan_to_cloud_filter_chain_nodelet ${catkin_LIBRARIES} ${Boost_LIBRARIES})
-target_compile_definitions(scan_to_cloud_filter_chain_nodelet PRIVATE BUILDING_NODELET=1)
-
 add_executable(scan_to_scan_filter_chain src/scan_to_scan_filter_chain.cpp)
 target_link_libraries(scan_to_scan_filter_chain ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+add_library(${PROJECT_NAME}_nodelets
+  src/scan_to_cloud_filter_chain.cpp
+  src/scan_to_scan_filter_chain.cpp)
+target_link_libraries(${PROJECT_NAME}_nodelets ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+target_compile_definitions(${PROJECT_NAME}_nodelets PRIVATE BUILDING_NODELET=1)
 
 add_executable(generic_laser_filter_node src/generic_laser_filter_node.cpp)
 target_link_libraries(generic_laser_filter_node ${catkin_LIBRARIES} ${Boost_LIBRARIES})
@@ -106,8 +108,8 @@ endif()
 
 install(TARGETS pointcloud_filters laser_scan_filters 
   scan_to_cloud_filter_chain
-  scan_to_cloud_filter_chain_nodelet
   scan_to_scan_filter_chain
+  ${PROJECT_NAME}_nodelets
   generic_laser_filter_node
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/nodelets.xml
+++ b/nodelets.xml
@@ -1,7 +1,12 @@
-<library path="lib/libscan_to_cloud_filter_chain_nodelet">
+<library path="lib/liblaser_filters_nodelets">
   <class name="laser_filters/scan_to_cloud_filter_chain" type="ScanToCloudFilterChainNodelet" base_class_type="nodelet::Nodelet">
     <description>
       Convert laser scans to pointclouds allowing to filter both as a scan and as a point cloud.
+    </description>
+  </class>
+  <class name="laser_filters/scan_to_scan_filter_chain" type="ScanToScanFilterChainNodelet" base_class_type="nodelet::Nodelet">
+    <description>
+      Laser scan filter pipeline
     </description>
   </class>
 </library>

--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -109,8 +109,8 @@ public:
   bool  incident_angle_correction_;
 
   ////////////////////////////////////////////////////////////////////////////////
-  ScanToCloudFilterChain (ros::NodeHandle& pnh, const std::string& name) :
-      laser_max_range_ (DBL_MAX), private_nh(pnh), name_(name), filter_(tf_, "", 50),
+  ScanToCloudFilterChain (ros::NodeHandle& nh_, ros::NodeHandle& pnh, const std::string& name) :
+      laser_max_range_ (DBL_MAX), nh(nh_), private_nh(pnh), name_(name), filter_(tf_, "", 50),
       cloud_filter_chain_("sensor_msgs::PointCloud2"), scan_filter_chain_("sensor_msgs::LaserScan")
   {
     private_nh.param("high_fidelity", high_fidelity_, false);
@@ -287,7 +287,7 @@ class ScanToCloudFilterChainNodelet : public nodelet::Nodelet
   std::unique_ptr<ScanToCloudFilterChain> chain_;
 
   void onInit() override {
-    chain_ = std::unique_ptr<ScanToCloudFilterChain>(new ScanToCloudFilterChain(getPrivateNodeHandle(), getName()));
+    chain_ = std::unique_ptr<ScanToCloudFilterChain>(new ScanToCloudFilterChain(getNodeHandle(), getPrivateNodeHandle(), getName()));
   }
 };
 
@@ -297,8 +297,8 @@ int
 main (int argc, char** argv)
 {
   ros::init (argc, argv, "scan_to_cloud_filter_chain");
-  ros::NodeHandle pnh("~");
-  ScanToCloudFilterChain f(pnh, "");
+  ros::NodeHandle nh, pnh("~");
+  ScanToCloudFilterChain f(nh, pnh, "");
 
   ros::spin();
 

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -35,6 +35,11 @@
 #include "tf/transform_listener.h"
 #include <filters/filter_chain.hpp>
 
+#if BUILDING_NODELET
+#include <nodelet/nodelet.h>
+#include <pluginlib/class_list_macros.h>
+#endif
+
 class ScanToScanFilterChain
 {
 protected:
@@ -61,11 +66,12 @@ protected:
 
 public:
   // Constructor
-  ScanToScanFilterChain() :
-    private_nh_("~"),
+  ScanToScanFilterChain(const ros::NodeHandle& nh = {}, const ros::NodeHandle& pnh = {"~"}) :
+    nh_(nh),
+    private_nh_(pnh),
+    tf_(nullptr),
     scan_sub_(nh_, "scan", 50),
-    tf_(NULL),
-    tf_filter_(NULL),
+    tf_filter_(nullptr),
     filter_chain_("sensor_msgs::LaserScan")
   {
     // Configure filter chain
@@ -136,6 +142,21 @@ public:
   }
 };
 
+#if BUILDING_NODELET
+
+class ScanToScanFilterChainNodelet : public nodelet::Nodelet
+{
+  std::unique_ptr<ScanToScanFilterChain> chain_;
+
+  void onInit() override {
+    chain_ = std::unique_ptr<ScanToScanFilterChain>(new ScanToScanFilterChain(getNodeHandle(), getPrivateNodeHandle()));
+  }
+};
+
+PLUGINLIB_EXPORT_CLASS(ScanToScanFilterChainNodelet, nodelet::Nodelet)
+
+#else
+
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "scan_to_scan_filter_chain");
@@ -145,3 +166,5 @@ int main(int argc, char **argv)
   
   return 0;
 }
+
+#endif


### PR DESCRIPTION
This PR adds the following updates:
- Fixes topic remapping for the `ScanToCloudFilterChain` nodelet
    -  In the current implementation, any topic remapping applied to the nodelet is ignored because the `ScanToCloudFilterChain` class uses its own public node handle, not the public node handle provided by the nodelet which accounts for topic remapping
- Adds a nodelet implementation for the `ScanToScanFilterChain` class
    - This class was also updated to accept public and private node handles from the nodelet to account for topic remapping correctly

Addresses #71 