### PR TITLE
Add Lazy subscription

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@ ament_auto_find_build_dependencies()
 # Build
 ##############################################################################
 
+if($ENV{ROS_DISTRO} STREQUAL "humble")
+    add_compile_definitions(IS_HUMBLE)
+endif()
+
 ament_auto_add_library(laser_scan_filters SHARED src/laser_scan_filters.cpp)
 ament_auto_add_library(laser_filter_chains SHARED
                          src/scan_to_cloud_filter_chain.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ ament_auto_find_build_dependencies()
 # Build
 ##############################################################################
 
-if($ENV{ROS_DISTRO} STREQUAL "humble")
-    add_compile_definitions(IS_HUMBLE)
+if(${rclcpp_VERSION_MAJOR} GREATER_EQUAL 20)
+    add_compile_definitions(RCLCPP_SUPPORTS_MATCHED_CALLBACKS)
 endif()
 
 ament_auto_add_library(laser_scan_filters SHARED src/laser_scan_filters.cpp)

--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,6 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>rclcpp_components</depend>
-  <depend>ros_environment</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>rclcpp_components</depend>
+  <depend>ros_environment</depend>
   <depend>sensor_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>

--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -54,7 +54,7 @@ ScanToCloudFilterChain::ScanToCloudFilterChain(
   read_only_desc.read_only = true;
 
   // Declare parameters
-  #ifndef IS_HUMBLE
+  #ifdef RCLCPP_SUPPORTS_MATCHED_CALLBACKS
   this->declare_parameter("lazy_subscription", false, read_only_desc);
   #endif
   this->declare_parameter("high_fidelity", false, read_only_desc);
@@ -64,7 +64,7 @@ ScanToCloudFilterChain::ScanToCloudFilterChain(
   this->declare_parameter("laser_max_range", DBL_MAX, read_only_desc);
 
   // Get parameters
-  #ifndef IS_HUMBLE
+  #ifdef RCLCPP_SUPPORTS_MATCHED_CALLBACKS
   this->get_parameter("lazy_subscription", lazy_subscription_);
   #endif
   this->get_parameter("high_fidelity", high_fidelity_);
@@ -85,7 +85,7 @@ ScanToCloudFilterChain::ScanToCloudFilterChain(
     this->get_node_timers_interface());
   buffer_.setCreateTimerInterface(timer_interface);
 
-  #ifndef IS_HUMBLE
+  #ifdef RCLCPP_SUPPORTS_MATCHED_CALLBACKS
   if (lazy_subscription_) {
     rclcpp::PublisherOptions pub_options;
     pub_options.event_callbacks.matched_callback =

--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -97,16 +97,14 @@ ScanToCloudFilterChain::ScanToCloudFilterChain(
           scan_sub_.subscribe(this, "scan", rmw_qos_profile_sensor_data);
         }
       };
-    cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("cloud_filtered",
-      rclcpp::SensorDataQoS(), pub_options);
+    cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
+      "cloud_filtered", 10, pub_options);
   } else {
-    cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("cloud_filtered",
-      rclcpp::SensorDataQoS());
+    cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("cloud_filtered", 10);
     scan_sub_.subscribe(this, "scan", rmw_qos_profile_sensor_data);
   }
   #else
-  cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
-    "cloud_filtered", rclcpp::SensorDataQoS());
+  cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("cloud_filtered", 10);
   scan_sub_.subscribe(this, "scan", rmw_qos_profile_sensor_data);
   #endif
 

--- a/src/scan_to_cloud_filter_chain.hpp
+++ b/src/scan_to_cloud_filter_chain.hpp
@@ -62,7 +62,7 @@ public:
   tf2_ros::Buffer buffer_;
   tf2_ros::TransformListener tf_;
 
-  message_filters::Subscriber<sensor_msgs::msg::LaserScan> sub_;
+  message_filters::Subscriber<sensor_msgs::msg::LaserScan> scan_sub_;
   tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan> filter_;
 
   filters::FilterChain<sensor_msgs::msg::PointCloud2> cloud_filter_chain_;
@@ -70,6 +70,9 @@ public:
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr cloud_pub_;
 
   // Parameters
+  #ifndef IS_HUMBLE
+  bool lazy_subscription_;
+  #endif
   bool high_fidelity_; // High fidelity (interpolating time across scan)
   double tf_tolerance_;
   std::string target_frame_; // Target frame for high fidelity result

--- a/src/scan_to_cloud_filter_chain.hpp
+++ b/src/scan_to_cloud_filter_chain.hpp
@@ -70,7 +70,7 @@ public:
   rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr cloud_pub_;
 
   // Parameters
-  #ifndef IS_HUMBLE
+  #ifdef RCLCPP_SUPPORTS_MATCHED_CALLBACKS
   bool lazy_subscription_;
   #endif
   bool high_fidelity_; // High fidelity (interpolating time across scan)

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -97,16 +97,14 @@ ScanToScanFilterChain::ScanToScanFilterChain(
           scan_sub_.subscribe(this, "scan", rmw_qos_profile_sensor_data);
         }
       };
-    output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan_filtered",
-      rclcpp::SensorDataQoS(), pub_options);
+    output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(
+      "scan_filtered", 1000, pub_options);
   } else {
-    output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan_filtered",
-      rclcpp::SensorDataQoS());
+    output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan_filtered", 1000);
     scan_sub_.subscribe(this, "scan", rmw_qos_profile_sensor_data);
   }
   #else
-  output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(
-    "scan_filtered", rclcpp::SensorDataQoS());
+  output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan_filtered", 1000);
   scan_sub_.subscribe(this, "scan", rmw_qos_profile_sensor_data);
   #endif
 }

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -50,14 +50,14 @@ ScanToScanFilterChain::ScanToScanFilterChain(
   read_only_desc.read_only = true;
 
   // Declare parameters
-  #ifndef IS_HUMBLE
+  #ifdef RCLCPP_SUPPORTS_MATCHED_CALLBACKS
   this->declare_parameter("lazy_subscription", false, read_only_desc);
   #endif
   this->declare_parameter("tf_message_filter_target_frame", "", read_only_desc);
   this->declare_parameter("tf_message_filter_tolerance", 0.03, read_only_desc);
 
   // Get parameters
-  #ifndef IS_HUMBLE
+  #ifdef RCLCPP_SUPPORTS_MATCHED_CALLBACKS
   this->get_parameter("lazy_subscription", lazy_subscription_);
   #endif
   this->get_parameter("tf_message_filter_target_frame", tf_message_filter_target_frame_);
@@ -85,7 +85,7 @@ ScanToScanFilterChain::ScanToScanFilterChain(
         std::placeholders::_1));
   }
 
-  #ifndef IS_HUMBLE
+  #ifdef RCLCPP_SUPPORTS_MATCHED_CALLBACKS
   if (lazy_subscription_) {
     rclcpp::PublisherOptions pub_options;
     pub_options.event_callbacks.matched_callback =

--- a/src/scan_to_scan_filter_chain.hpp
+++ b/src/scan_to_scan_filter_chain.hpp
@@ -58,6 +58,9 @@ protected:
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr output_pub_;
 
   // Parameters
+  #ifndef IS_HUMBLE
+  bool lazy_subscription_;
+  #endif
   std::string tf_message_filter_target_frame_;
   double tf_filter_tolerance_;
 

--- a/src/scan_to_scan_filter_chain.hpp
+++ b/src/scan_to_scan_filter_chain.hpp
@@ -58,7 +58,7 @@ protected:
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr output_pub_;
 
   // Parameters
-  #ifndef IS_HUMBLE
+  #ifdef RCLCPP_SUPPORTS_MATCHED_CALLBACKS
   bool lazy_subscription_;
   #endif
   std::string tf_message_filter_target_frame_;


### PR DESCRIPTION
Implements #194 .

this requires Matched publisher events, which are supported from ROS Iron onward, so a separate branch for ROS Humble is required.

This PR also fixes some issues with parameters in scan filter chains:
1. Explicitly declare all parameters , otherwise `get_parameter` won't work.
2. Remove unused parameters.
3. Add read-only flag to all parameters as the filter chains don't support dynamically changing them.

I also changed `spin_some` to `spin` as I see absolutely no reason to use the first method.

I can split this PR into multiple ones if needed,