### PR TITLE
Update list of ros2 distros to test on

### DIFF
--- a/.github/workflows/ros2_ci.yml
+++ b/.github/workflows/ros2_ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rosdistro: [foxy, galactic, humble, rolling]
+        rosdistro: [humble, iron, jazzy, rolling]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Foxy and galactic are EOL; Iron is now supported.