### PR TITLE
Don't use shared_from_this in the constructor

### DIFF
--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -46,7 +46,8 @@ ScanToCloudFilterChain::ScanToCloudFilterChain(
   buffer_(this->get_clock()),
   tf_(buffer_),
   sub_(this, "scan", rmw_qos_profile_sensor_data),
-  filter_(sub_, buffer_, "", 50, this->shared_from_this()),
+  filter_(sub_, buffer_, "", 50, this->get_node_logging_interface(),
+    this->get_node_clock_interface()),
   cloud_filter_chain_("sensor_msgs::msg::PointCloud2"),
   scan_filter_chain_("sensor_msgs::msg::LaserScan")
 {

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -56,7 +56,7 @@ ScanToScanFilterChain::ScanToScanFilterChain(
     tf_filter_.reset(
       new tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>(
         scan_sub_, buffer_, "",
-        50, this->shared_from_this()));
+        50, this->get_node_logging_interface(), this->get_node_clock_interface()));
     tf_filter_->setTargetFrame(tf_message_filter_target_frame);
     tf_filter_->setTolerance(std::chrono::duration<double>(tf_filter_tolerance_));
 


### PR DESCRIPTION
Using shared_from_this inside a constructor is dangerous:

> If shared_from_this is called on an object that is not previously shared by [std::shared_ptr](https://en.cppreference.com/w/cpp/memory/shared_ptr), [std::bad_weak_ptr](https://en.cppreference.com/w/cpp/memory/bad_weak_ptr) is thrown (by the shared_ptr constructor from a default-constructed weak-this).

Right now, running `scan_to_cloud_filter_chain` results in `std::bad_weak_ptr` exception.

This PR fixes it by using a different constructor for `tf2_ros::MessageFilter`