### PR TITLE
Spatial median filter

### DIFF
--- a/examples/median_spatial_filter.launch.py
+++ b/examples/median_spatial_filter.launch.py
@@ -1,0 +1,18 @@
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from ament_index_python.packages import get_package_share_directory
+
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package="laser_filters",
+            executable="scan_to_scan_filter_chain",
+            parameters=[
+                PathJoinSubstitution([
+                    get_package_share_directory("laser_filters"),
+                    "examples", "median_spatial_filter_example.yaml",
+                ])],
+        )
+    ])

--- a/examples/median_spatial_filter.launch.xml
+++ b/examples/median_spatial_filter.launch.xml
@@ -1,0 +1,5 @@
+<launch>
+    <node name="scan_to_scan_filter_chain" pkg="laser_filters" exec="scan_to_scan_filter_chain" output="screen">
+        <param from="$(find-pkg-share laser_filters)/examples/median_spatial_filter_example.yaml" />
+    </node>
+</launch>

--- a/examples/median_spatial_filter_example.yaml
+++ b/examples/median_spatial_filter_example.yaml
@@ -1,0 +1,17 @@
+scan_to_scan_filter_chain:
+  ros__parameters:
+    filter1:
+      name: median_spatial
+      type: laser_filters/LaserScanMedianSpatialFilter
+      params:
+        window_size: 31
+    filter2:
+      name: median_filter
+      type: laser_filters/LaserArrayFilter
+      params:
+        range_filter_chain:
+          filter1:
+            name: median
+            type: filters/MultiChannelMedianFilterFloat
+            params:
+              number_of_observations: 3

--- a/include/laser_filters/median_spatial_filter.h
+++ b/include/laser_filters/median_spatial_filter.h
@@ -1,0 +1,122 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2017, laser_filters authors
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of the Willow Garage nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/*
+\author Yannic Bachmann
+*/
+
+#ifndef LASER_SCAN_MEDIAN_SPATIAL_FILTER_H
+#define LASER_SCAN_MEDIAN_SPATIAL_FILTER_H
+
+#include "filters/filter_base.hpp"
+#include <sensor_msgs/msg/laser_scan.hpp>
+#include <algorithm>
+#include <vector>
+#include <stdexcept>
+
+namespace laser_filters
+{
+
+class LaserScanMedianSpatialFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan>
+{
+public:
+  int window_size_;
+
+  bool configure()
+  {
+    // Default window size
+    window_size_ = 3;
+    getParam("window_size", window_size_);
+
+    // Ensure window size is positive
+    if (window_size_ <= 0)
+    {
+      throw std::runtime_error("Window size must be positive");
+    }
+
+    // Ensure window size is odd
+    if (window_size_ % 2 == 0)
+    {
+      window_size_ += 1;
+    }
+
+    return true;
+  }
+
+  virtual ~LaserScanMedianSpatialFilter() {}
+
+  bool update(const sensor_msgs::msg::LaserScan &input_scan, sensor_msgs::msg::LaserScan &filtered_scan)
+  {
+    filtered_scan = input_scan;
+
+    int half_window = window_size_ / 2;
+    std::vector<float> window;
+
+    for (size_t i = 0; i < input_scan.ranges.size(); ++i)
+    {
+      window.clear();
+
+      // Collect points within the window
+      for (int j = -half_window; j <= half_window; ++j)
+      {
+        int index = i + j;
+
+        if (index >= 0 && index < input_scan.ranges.size())
+        {
+          if (!std::isnan(input_scan.ranges[index]))
+          {
+            window.push_back(input_scan.ranges[index]);
+          }
+        }
+      }
+
+      if (!window.empty())
+      {
+        // Calculate median
+        std::sort(window.begin(), window.end());
+        filtered_scan.ranges[i] = window[window.size() / 2];
+      }
+      else
+      {
+        filtered_scan.ranges[i] = std::numeric_limits<float>::quiet_NaN();
+      }
+    }
+
+    return true;
+  }
+};
+
+} // namespace laser_filters
+
+#endif // LASER_SCAN_MEDIAN_SPATIAL_FILTER_H

--- a/include/laser_filters/median_spatial_filter.h
+++ b/include/laser_filters/median_spatial_filter.h
@@ -59,14 +59,13 @@ public:
 
   bool configure()
   {
-    // Default window size
-    window_size_ = 3;
     getParam("window_size", window_size_);
 
     // Ensure window size is positive
     if (window_size_ <= 0)
     {
-      throw std::runtime_error("Window size must be positive");
+      RCLCPP_ERROR(logging_interface_->get_logger(), "Window size must be positive.\n");
+      return false;
     }
 
     // Ensure window size is odd

--- a/include/laser_filters/median_spatial_filter.h
+++ b/include/laser_filters/median_spatial_filter.h
@@ -69,8 +69,10 @@ public:
     }
 
     // Ensure window size is odd
+    // If the window_size is even, the current range, which will be modified cannot be centered in the window.
     if (window_size_ % 2 == 0)
     {
+      RCLCPP_WARN(logging_interface_->get_logger(), "Window size must be odd. Automatically setting window_size to %d instead of %d.\n", window_size_+1, window_size_);
       window_size_ += 1;
     }
 

--- a/include/laser_filters/speckle_filter.h
+++ b/include/laser_filters/speckle_filter.h
@@ -40,9 +40,6 @@
 #ifndef SPECKLE_FILTER_H
 #define SPECKLE_FILTER_H
 
-#include <cmath>
-#include <iostream>
-
 #include <filters/filter_base.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
 
@@ -52,71 +49,13 @@ namespace laser_filters
 enum SpeckleFilterType //Enum to select the filtering method
 {
   Distance = 0, // Range based filtering (distance between consecutive points
-  RadiusOutlier = 1, // Euclidean filtering based on radius outlier search
-  DistanceMovingWindow = 2 // Range based filtering based on number of in- and outliers
+  RadiusOutlier = 1 // Euclidean filtering based on radius outlier search
 };
 
 class WindowValidator
 {
 public:
   virtual bool checkWindowValid(const sensor_msgs::msg::LaserScan& scan, size_t idx, size_t window, double max_range_difference) = 0;
-};
-
-class DistanceMovingWindowValidator : public WindowValidator
-{
-  virtual bool checkWindowValid(const sensor_msgs::msg::LaserScan& scan, size_t idx, size_t window, double max_range_difference)
-  {
-    const size_t half_window = std::floor(window/2.0);
-
-    const float& range = scan.ranges[idx];
-    if (std::isnan(range)) {
-      return false;
-    }
-
-    size_t nr_inliers = 0;
-    size_t nr_outliers = 0;
-
-    auto check_in_out_lier = [&](const size_t neighbor_idx)
-    {
-      const float& neighbor_range = scan.ranges[neighbor_idx];
-      if (std::isnan(neighbor_range) || fabs(neighbor_range - range) > max_range_difference)
-      {
-        nr_outliers++;
-      }
-      else
-      {
-        nr_inliers++;
-      }
-      return;
-    };
-
-    for (size_t neighbor_idx_nr = 1; neighbor_idx_nr <= half_window; ++neighbor_idx_nr)
-    {
-      // check points before index if possible side of the
-      if (idx >= neighbor_idx_nr)  // out of bounds check
-      {
-        const size_t neighbor_idx = idx - neighbor_idx_nr;
-        check_in_out_lier(neighbor_idx);
-      }
-
-      // check points after the index
-      const size_t neighbor_idx = idx + neighbor_idx_nr;
-      if (neighbor_idx < scan.ranges.size())  // Out of bound check
-      {
-        check_in_out_lier(neighbor_idx);
-      }
-    }
-
-    // more aggressive removal if the number is the same
-    // ignore filter if both values are equal 0
-    if (!(nr_outliers != 0 && nr_inliers != 0) && nr_outliers >= nr_inliers)
-    {
-      std::cout << "Filtered out: " << idx << " inliner: " << nr_inliers << "; outliers: " << nr_outliers << std::endl;
-      return false;
-    }
-
-    return true;
-  }
 };
 
 class DistanceWindowValidator : public WindowValidator
@@ -274,15 +213,6 @@ public:
           delete validator_;
         }
         validator_ = new laser_filters::DistanceWindowValidator();
-        break;
-
-      case laser_filters::SpeckleFilterType::DistanceMovingWindow:
-        if (validator_)
-        {
-          delete validator_;
-        }
-        validator_ = new laser_filters::DistanceMovingWindowValidator();
-        RCLCPP_ERROR_EXPRESSION(node_->get_logger(), filter_window < 2, "SpackleFilter needs window of at least size 2 to work properly. Please update the parameter and restart the filter!");
         break;
 
       default:

--- a/laser_filters_plugins.xml
+++ b/laser_filters_plugins.xml
@@ -1,4 +1,4 @@
-d<class_libraries>
+<class_libraries>
   <library path="laser_scan_filters">
     <class name="laser_filters/LaserArrayFilter" type="laser_filters::LaserArrayFilter" 
 	    base_class_type="filters::FilterBase&lt;sensor_msgs::msg::LaserScan&gt;">

--- a/laser_filters_plugins.xml
+++ b/laser_filters_plugins.xml
@@ -60,6 +60,12 @@
 	 This is a filter that removes points on directions defined in a mask from a laser scan.
       </description>
     </class>
+    <class name="laser_filters/LaserScanMedianSpatialFilter" type="laser_filters::LaserScanMedianSpatialFilter" 
+	    base_class_type="filters::FilterBase&lt;sensor_msgs::msg::LaserScan&gt;">
+      <description>
+	This is a spatial 1D median filter which filters sensor_msgs::msg::LaserScan messages.  
+      </description>
+    </class>
     <class name="laser_filters/LaserMedianFilter" type="laser_filters::LaserMedianFilter" 
 	    base_class_type="filters::FilterBase&lt;sensor_msgs::msg::LaserScan&gt;">
       <description>

--- a/laser_filters_plugins.xml
+++ b/laser_filters_plugins.xml
@@ -1,4 +1,4 @@
-<class_libraries>
+d<class_libraries>
   <library path="laser_scan_filters">
     <class name="laser_filters/LaserArrayFilter" type="laser_filters::LaserArrayFilter" 
 	    base_class_type="filters::FilterBase&lt;sensor_msgs::msg::LaserScan&gt;">
@@ -63,7 +63,7 @@
     <class name="laser_filters/LaserScanMedianSpatialFilter" type="laser_filters::LaserScanMedianSpatialFilter" 
 	    base_class_type="filters::FilterBase&lt;sensor_msgs::msg::LaserScan&gt;">
       <description>
-	This is a spatial 1D median filter which filters sensor_msgs::msg::LaserScan messages.  
+	This is a spatial 1D median filter which filters sensor_msgs::msg::LaserScan messages. It smoothes continuous obstacles/walls and removes isolated/scattered noise.
       </description>
     </class>
     <class name="laser_filters/LaserMedianFilter" type="laser_filters::LaserMedianFilter" 

--- a/src/laser_scan_filters.cpp
+++ b/src/laser_scan_filters.cpp
@@ -28,6 +28,7 @@
  */
 
 #include "laser_filters/median_filter.h"
+#include "laser_filters/median_spatial_filter.h"
 #include "laser_filters/array_filter.h"
 #include "laser_filters/intensity_filter.h"
 #include "laser_filters/range_filter.h"
@@ -46,6 +47,7 @@
 #include <pluginlib/class_list_macros.hpp>  // NOLINT
 
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserMedianFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
+PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanMedianSpatialFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserArrayFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanIntensityFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)
 PLUGINLIB_EXPORT_CLASS(laser_filters::LaserScanRangeFilter, filters::FilterBase<sensor_msgs::msg::LaserScan>)


### PR DESCRIPTION
This PR adds a 1D spatial median filter. 
The size of the filter can be set via the parameter `window_size`. 

In this screenshot you can see the raw laserscan in blue and the result of the spatial median filter in red (`window_size=31`). 
The filter smoothes the walls and also removes isolated/scattered noise (see e.g. directly right of the robot). 
![spatial_median_filter](https://github.com/user-attachments/assets/804a5350-11c9-4bdd-80cb-b060610f9424)
