### PR TITLE
Add missing dependency on ament launch testing

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
   <depend>tf2_kdl</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Seeing some breaking dev jobs on the build farm.