### PR TITLE
Dynamic setting of params in speckle filter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ if(${rclcpp_VERSION_MAJOR} GREATER_EQUAL 20)
     add_compile_definitions(RCLCPP_SUPPORTS_MATCHED_CALLBACKS)
 endif()
 
+if(${rclcpp_VERSION_MAJOR} GREATER_EQUAL 17)
+    add_compile_definitions(RCLCPP_SUPPORTS_POST_SET_PARAMS_CALLBACK)
+endif()
+
 ament_auto_add_library(laser_scan_filters SHARED src/laser_scan_filters.cpp)
 ament_auto_add_library(laser_filter_chains SHARED
                          src/scan_to_cloud_filter_chain.cpp

--- a/include/laser_filters/speckle_filter.h
+++ b/include/laser_filters/speckle_filter.h
@@ -174,6 +174,18 @@ public:
 
   ///////////////////////////////////////////////////////////////
   bool configure(){
+
+    #ifdef RCLCPP_SUPPORTS_POST_SET_PARAMS_CALLBACK
+    // Declare parameters as writeable. Otherwise, the first time we call FilterBase::getParam() for each one,
+    // it will get declared as write only.
+    rcl_interfaces::msg::ParameterDescriptor desc;
+    desc.read_only = true;
+    params_interface_->declare_parameter("filter_type", rclcpp::ParameterType::PARAMETER_INTEGER, desc);
+    params_interface_->declare_parameter("max_range", rclcpp::ParameterType::PARAMETER_DOUBLE, desc);
+    params_interface_->declare_parameter("max_range_difference", rclcpp::ParameterType::PARAMETER_DOUBLE, desc);
+    params_interface_->declare_parameter("filter_window", rclcpp::ParameterType::PARAMETER_INTEGER, desc);
+    #endif
+
     // get params
     if (!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("filter_type"), filter_type))
     {

--- a/include/laser_filters/speckle_filter.h
+++ b/include/laser_filters/speckle_filter.h
@@ -214,8 +214,10 @@ public:
         break;
     }
 
+    #ifdef RCLCPP_SUPPORTS_POST_SET_PARAMS_CALLBACK
     post_set_parameters_callback_handle_ = params_interface_->add_post_set_parameters_callback(
             std::bind(&LaserScanSpeckleFilter::reconfigureCB, this, std::placeholders::_1));
+    #endif
 
     return true;
   }
@@ -300,7 +302,10 @@ private:
   double max_range = 0;
   double max_range_difference = 0;
   int filter_window = 0;
+
+  #ifdef RCLCPP_SUPPORTS_POST_SET_PARAMS_CALLBACK
   rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr post_set_parameters_callback_handle_;
+  #endif // RCLCPP_SUPPORTS_POST_SET_PARAMS_CALLBACK
 };
 }
 #endif /* speckle_filter.h */

--- a/include/laser_filters/speckle_filter.h
+++ b/include/laser_filters/speckle_filter.h
@@ -214,6 +214,9 @@ public:
         break;
     }
 
+    post_set_parameters_callback_handle_ = params_interface_->add_post_set_parameters_callback(
+            std::bind(&LaserScanSpeckleFilter::reconfigureCB, this, std::placeholders::_1));
+
     return true;
   }
   /////////////////////////////////////////////////////
@@ -248,11 +251,8 @@ public:
     return true;
   }
 
-  rcl_interfaces::msg::SetParametersResult reconfigureCB(std::vector<rclcpp::Parameter> parameters)
+  void reconfigureCB(std::vector<rclcpp::Parameter> parameters)
   {
-      auto result = rcl_interfaces::msg::SetParametersResult();
-      result.successful = true;
-
       for (auto parameter : parameters)
       {
         if(logging_interface_ != nullptr)
@@ -289,9 +289,6 @@ public:
       default:
         break;
     }
-
-    return result;
-
   }
 
   ////////////////////////////////////////////////////
@@ -303,6 +300,7 @@ private:
   double max_range = 0;
   double max_range_difference = 0;
   int filter_window = 0;
+  rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr post_set_parameters_callback_handle_;
 };
 }
 #endif /* speckle_filter.h */


### PR DESCRIPTION
Done previously by berend-kupers, but removed during code review because we thought it needed a separate node inside the filter. Here we use the params_interface_ member variable of the filter base class instead of creating a new node.

The callback needs to be post_set_params and not on_set_params because the changes haven't been finalized yet when on_set_params is called.