### PR TITLE
Deprecate c headers

### DIFF
--- a/include/laser_filters/box_filter.h
+++ b/include/laser_filters/box_filter.h
@@ -49,7 +49,7 @@
 
 #include <filters/filter_base.hpp>
 
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 #include <tf2_ros/transform_listener.h>
 #include <sensor_msgs/msg/laser_scan.hpp>
 

--- a/include/laser_filters/footprint_filter.h
+++ b/include/laser_filters/footprint_filter.h
@@ -43,7 +43,7 @@ This is useful for ground plane extraction
 
 #include "filters/filter_base.hpp"
 
-#include <tf2/transform_datatypes.h>
+#include <tf2/transform_datatypes.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <sensor_msgs/msg/laser_scan.hpp>


### PR DESCRIPTION
Related to this [pull request](https://github.com/ros2/geometry2/pull/720) in `geometry2` in which we deprecated the `.h` style headers in favor of `.hpp`.