### PR TITLE
Added params_prefix to reconfigure callback

### DIFF
--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -309,17 +309,19 @@ protected:
 
     for (auto parameter : parameters)
     {
-      if(parameter.get_name() == "polygon"&& parameter.get_type() == rclcpp::ParameterType::PARAMETER_STRING){
+      if(logging_interface_ != nullptr)
+          RCLCPP_INFO_STREAM(logging_interface_->get_logger(), "Update parameter " << parameter.get_name().c_str()<< " to "<<parameter);
+      if(parameter.get_name() == param_prefix_+"polygon"&& parameter.get_type() == rclcpp::ParameterType::PARAMETER_STRING){
         std::string polygon_string = parameter.as_string();
         polygon_ = makePolygonFromString(polygon_string, polygon_);
       }
-      else if(parameter.get_name() == "polygon_frame" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_STRING){
+      else if(parameter.get_name() == param_prefix_+"polygon_frame" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_STRING){
         polygon_frame_ = parameter.as_string();
       }
-      else if(parameter.get_name() == "invert" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_BOOL){
+      else if(parameter.get_name() == param_prefix_+"invert" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_BOOL){
         invert_filter_ = parameter.as_bool();
       }
-      else if(parameter.get_name() == "polygon_padding" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE){
+      else if(parameter.get_name() == param_prefix_+"polygon_padding" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE){
         polygon_padding_ = parameter.as_double();
       }
       else{

--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -310,7 +310,7 @@ protected:
     for (auto parameter : parameters)
     {
       if(logging_interface_ != nullptr)
-          RCLCPP_INFO_STREAM(logging_interface_->get_logger(), "Update parameter " << parameter.get_name().c_str()<< " to "<<parameter);
+          RCLCPP_DEBUG_STREAM(logging_interface_->get_logger(), "Update parameter " << parameter.get_name().c_str()<< " to "<<parameter);
       if(parameter.get_name() == param_prefix_+"polygon"&& parameter.get_type() == rclcpp::ParameterType::PARAMETER_STRING){
         std::string polygon_string = parameter.as_string();
         polygon_ = makePolygonFromString(polygon_string, polygon_);

--- a/include/laser_filters/scan_shadows_filter.h
+++ b/include/laser_filters/scan_shadows_filter.h
@@ -195,15 +195,17 @@ public:
 
     for (auto parameter : parameters)
     {
-      if(parameter.get_name() == "min_angle"&& parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
+      if(logging_interface_ != nullptr)
+          RCLCPP_INFO_STREAM(logging_interface_->get_logger(), "Update parameter " << parameter.get_name().c_str()<< " to "<<parameter);
+      if(parameter.get_name() == param_prefix_+"min_angle"&& parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
           min_angle_ = parameter.as_double();
-      else if(parameter.get_name() == "max_angle" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
+      else if(parameter.get_name() == param_prefix_+"max_angle" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
           max_angle_ = parameter.as_double();
-      else if(parameter.get_name() == "neighbors" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
+      else if(parameter.get_name() == param_prefix_+"neighbors" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
           neighbors_ = parameter.as_int();
-      else if(parameter.get_name() == "window" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
+      else if(parameter.get_name() == param_prefix_+"window" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
           window_ = parameter.as_int();
-      else if(parameter.get_name() == "remove_shadow_start_point" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_BOOL)
+      else if(parameter.get_name() == param_prefix_+"remove_shadow_start_point" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_BOOL)
           remove_shadow_start_point_ = parameter.as_bool(); 
     }
     shadow_detector_.configure(

--- a/include/laser_filters/scan_shadows_filter.h
+++ b/include/laser_filters/scan_shadows_filter.h
@@ -196,7 +196,7 @@ public:
     for (auto parameter : parameters)
     {
       if(logging_interface_ != nullptr)
-          RCLCPP_INFO_STREAM(logging_interface_->get_logger(), "Update parameter " << parameter.get_name().c_str()<< " to "<<parameter);
+          RCLCPP_DEBUG_STREAM(logging_interface_->get_logger(), "Update parameter " << parameter.get_name().c_str()<< " to "<<parameter);
       if(parameter.get_name() == param_prefix_+"min_angle"&& parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
           min_angle_ = parameter.as_double();
       else if(parameter.get_name() == param_prefix_+"max_angle" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)

--- a/include/laser_filters/speckle_filter.h
+++ b/include/laser_filters/speckle_filter.h
@@ -256,7 +256,7 @@ public:
       for (auto parameter : parameters)
       {
         if(logging_interface_ != nullptr)
-          RCLCPP_INFO_STREAM(logging_interface_->get_logger(), "Update parameter " << parameter.get_name().c_str()<< " to "<<parameter);
+          RCLCPP_DEBUG_STREAM(logging_interface_->get_logger(), "Update parameter " << parameter.get_name().c_str()<< " to "<<parameter);
         if(parameter.get_name() == param_prefix_+"filter_type"&& parameter.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
             filter_type = parameter.as_int();
         else if(parameter.get_name() == param_prefix_+"max_range" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)

--- a/include/laser_filters/speckle_filter.h
+++ b/include/laser_filters/speckle_filter.h
@@ -257,13 +257,13 @@ public:
       {
         if(logging_interface_ != nullptr)
           RCLCPP_INFO_STREAM(logging_interface_->get_logger(), "Update parameter " << parameter.get_name().c_str()<< " to "<<parameter);
-        if(parameter.get_name() == "filter_type"&& parameter.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
+        if(parameter.get_name() == param_prefix_+"filter_type"&& parameter.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
             filter_type = parameter.as_int();
-        else if(parameter.get_name() == "max_range" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
+        else if(parameter.get_name() == param_prefix_+"max_range" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
             max_range = parameter.as_double();
-        else if(parameter.get_name() == "max_range_difference" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
+        else if(parameter.get_name() == param_prefix_+"max_range_difference" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_DOUBLE)
             max_range_difference = parameter.as_double();
-        else if(parameter.get_name() == "filter_window" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
+        else if(parameter.get_name() == param_prefix_+"filter_window" && parameter.get_type() == rclcpp::ParameterType::PARAMETER_INTEGER)
             filter_window = parameter.as_int();
         else
           if(logging_interface_ != nullptr) RCLCPP_WARN(logging_interface_->get_logger(), "Unknown parameter");


### PR DESCRIPTION
To be able to use the reconfigure callback properly the "params_prefix_" is necessary to compare correctly. Otherwise it would throw "unknown parameter" when I try to update filter#.params.parameter_a because it looks for parameter_a