### PR TITLE
Use correct footprint subscriber callback for static polygon filter

### DIFF
--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -234,7 +234,7 @@ public:
               std::bind(&LaserScanPolygonFilterBase::reconfigureCB, this, std::placeholders::_1));
 
     std::string polygon_string;
-    if(!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("footprint_topic"), footprint_topic_, "base_footprint_exclude"))
+    if(!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("footprint_topic"), footprint_topic_, false, "base_footprint_exclude"))
     {
       RCLCPP_WARN(logging_interface_->get_logger(), "Footprint topic not set, assuming default: base_footprint_exclude");
     }

--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -236,15 +236,14 @@ public:
     std::string polygon_string;
     invert_filter_ = false;
     polygon_padding_ = 0;
-    std::string footprint_topic;
-    if(!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("footprint_topic"), footprint_topic))
+    if(!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("footprint_topic"), footprint_topic_))
     {
       RCLCPP_WARN(logging_interface_->get_logger(), "Footprint topic not set, assuming default: base_footprint_exclude");
     }
     // Set default footprint topic
-    if(footprint_topic=="")
+    if(footprint_topic_=="")
     {
-      footprint_topic = "base_footprint_exclude";
+      footprint_topic_ = "base_footprint_exclude";
     }
     if (!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("polygon"), polygon_string))
     {
@@ -264,7 +263,6 @@ public:
     polygon_ = makePolygonFromString(polygon_string, polygon_);
     padPolygon(polygon_, polygon_padding_);
     
-    footprint_sub_ = create_subscription<geometry_msgs::msg::Polygon>(footprint_topic, 1, std::bind(&LaserScanPolygonFilterBase::footprintCB, this, std::placeholders::_1));
     polygon_pub_ = create_publisher<geometry_msgs::msg::PolygonStamped>("polygon", rclcpp::QoS(1).transient_local().keep_last(1));
     is_polygon_published_ = false;
     
@@ -293,6 +291,7 @@ protected:
   geometry_msgs::msg::Polygon polygon_;
   double polygon_padding_;
   bool invert_filter_;
+  std::string footprint_topic_;
   bool is_polygon_published_ = false;
   
 
@@ -367,6 +366,7 @@ public:
   bool configure() override
   {
     bool result = LaserScanPolygonFilterBase::configure();
+    footprint_sub_ = node_->create_subscription<geometry_msgs::msg::Polygon>(footprint_topic_, 1, std::bind(&LaserScanPolygonFilterBase::footprintCB, this, std::placeholders::_1));
     return result;
   }
 
@@ -484,6 +484,7 @@ public:
     {
       RCLCPP_INFO(logging_interface_->get_logger(), "Error: PolygonFilter transform_timeout not set, assuming 5. \n");
     }
+    footprint_sub_ = node_->create_subscription<geometry_msgs::msg::Polygon>(footprint_topic_, 1, std::bind(&StaticLaserScanPolygonFilter::footprintCB, this, std::placeholders::_1));
     return result;
   }
 

--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -234,16 +234,9 @@ public:
               std::bind(&LaserScanPolygonFilterBase::reconfigureCB, this, std::placeholders::_1));
 
     std::string polygon_string;
-    invert_filter_ = false;
-    polygon_padding_ = 0;
-    if(!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("footprint_topic"), footprint_topic_))
+    if(!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("footprint_topic"), footprint_topic_, "base_footprint_exclude"))
     {
       RCLCPP_WARN(logging_interface_->get_logger(), "Footprint topic not set, assuming default: base_footprint_exclude");
-    }
-    // Set default footprint topic
-    if(footprint_topic_=="")
-    {
-      footprint_topic_ = "base_footprint_exclude";
     }
     if (!filters::FilterBase<sensor_msgs::msg::LaserScan>::getParam(std::string("polygon"), polygon_string))
     {

--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -366,7 +366,7 @@ public:
   bool configure() override
   {
     bool result = LaserScanPolygonFilterBase::configure();
-    footprint_sub_ = node_->create_subscription<geometry_msgs::msg::Polygon>(footprint_topic_, 1, std::bind(&LaserScanPolygonFilterBase::footprintCB, this, std::placeholders::_1));
+    footprint_sub_ = create_subscription<geometry_msgs::msg::Polygon>(footprint_topic_, 1, std::bind(&LaserScanPolygonFilterBase::footprintCB, this, std::placeholders::_1));
     return result;
   }
 
@@ -484,7 +484,7 @@ public:
     {
       RCLCPP_INFO(logging_interface_->get_logger(), "Error: PolygonFilter transform_timeout not set, assuming 5. \n");
     }
-    footprint_sub_ = node_->create_subscription<geometry_msgs::msg::Polygon>(footprint_topic_, 1, std::bind(&StaticLaserScanPolygonFilter::footprintCB, this, std::placeholders::_1));
+    footprint_sub_ = create_subscription<geometry_msgs::msg::Polygon>(footprint_topic_, 1, std::bind(&StaticLaserScanPolygonFilter::footprintCB, this, std::placeholders::_1));
     return result;
   }
 


### PR DESCRIPTION
Footprint subscriber for static polygon filter was only using the callback function of the base class and not the overrided function in the child class.