### PR TITLE
Added heartbeat diagnostics

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,8 @@
   <build_depend>ament_cmake_auto</build_depend>
 
   <depend>angles</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>diagnostic_updater</depend>
   <depend>filters</depend>
   <depend>laser_geometry</depend>
   <depend>message_filters</depend>

--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -42,6 +42,7 @@ ScanToCloudFilterChain::ScanToCloudFilterChain(
   const rclcpp::NodeOptions & options,
   const std::string & ns)
 : rclcpp::Node("scan_to_cloud_filter_chain", ns, options),
+  diagnostic_updater_(this),
   laser_max_range_(DBL_MAX),
   buffer_(this->get_clock()),
   tf_(buffer_),
@@ -50,6 +51,9 @@ ScanToCloudFilterChain::ScanToCloudFilterChain(
   cloud_filter_chain_("sensor_msgs::msg::PointCloud2"),
   scan_filter_chain_("sensor_msgs::msg::LaserScan")
 {
+  // Heartbeat diagnostics
+  diagnostic_updater_.add(heartbeat_diagnostics_);
+
   rcl_interfaces::msg::ParameterDescriptor read_only_desc;
   read_only_desc.read_only = true;
 

--- a/src/scan_to_cloud_filter_chain.hpp
+++ b/src/scan_to_cloud_filter_chain.hpp
@@ -33,6 +33,8 @@
 
 
  */
+#include <diagnostic_updater/diagnostic_updater.hpp>
+#include <diagnostic_updater/update_functions.hpp>
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -85,4 +87,8 @@ public:
 
   void
   scanCallback(const std::shared_ptr<const sensor_msgs::msg::LaserScan> & scan_msg);
+
+  // Diagnostic updater
+  diagnostic_updater::Heartbeat heartbeat_diagnostics_;
+  diagnostic_updater::Updater diagnostic_updater_;
 };

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -36,11 +36,15 @@ ScanToScanFilterChain::ScanToScanFilterChain(
   const rclcpp::NodeOptions & options,
   const std::string & ns)
 : rclcpp::Node("scan_to_scan_filter_chain", ns, options),
+  diagnostic_updater_(this),
   tf_(NULL),
   buffer_(this->get_clock()),
   tf_filter_(NULL),
   filter_chain_("sensor_msgs::msg::LaserScan")
 {
+  // Heartbeat diagnostics
+  diagnostic_updater_.add(heartbeat_diagnostics_);
+  
   // Configure filter chain
   filter_chain_.configure(
     "",

--- a/src/scan_to_scan_filter_chain.hpp
+++ b/src/scan_to_scan_filter_chain.hpp
@@ -27,6 +27,8 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <diagnostic_updater/diagnostic_updater.hpp>
+#include <diagnostic_updater/update_functions.hpp>
 
 #include <rclcpp/rclcpp.hpp>
 #include <sensor_msgs/msg/laser_scan.hpp>
@@ -63,6 +65,10 @@ protected:
   #endif
   std::string tf_message_filter_target_frame_;
   double tf_filter_tolerance_;
+
+  // Diagnostic updater
+  diagnostic_updater::Heartbeat heartbeat_diagnostics_;
+  diagnostic_updater::Updater diagnostic_updater_;
 
 public:
   // Constructor


### PR DESCRIPTION
Since the segfault crash fixed with #216, we added heartbeat diagnostics to the nodes, so the robot can go into error state when a node has crashed. What do you think about it?
 
 PS: No pressure on solving all these PR's quickly, lets just keep a steady pace :)