### PR TITLE
Removed deprecations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,12 @@ if(BUILD_TESTING)
     set(TEST_NAME test_scan_filter_chain)
     set(RESULT_FILENAME ${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${TEST_NAME}.gtest.xml)
     ament_add_gtest_executable(${TEST_NAME} test/${TEST_NAME}.cpp)
-    ament_target_dependencies(${TEST_NAME} filters pluginlib rclcpp sensor_msgs)
+    target_link_libraries(${TEST_NAME}
+        pluginlib::pluginlib
+        rclcpp::rclcpp
+        filters::filter_chain
+        ${sensor_msgs_TARGETS}
+    )
     ament_add_test(
         ${TEST_NAME}
         COMMAND
@@ -67,8 +72,10 @@ if(BUILD_TESTING)
     set(TEST_NAME test_shadow_detector)
     set(RESULT_FILENAME ${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${TEST_NAME}.gtest.xml)
     ament_add_gtest_executable(${TEST_NAME} test/${TEST_NAME}.cpp)
-    ament_target_dependencies(${TEST_NAME} angles)
-    target_link_libraries(${TEST_NAME} laser_scan_filters)
+    target_link_libraries(${TEST_NAME}
+        angles::angles
+        laser_scan_filters
+    )
     ament_add_test(
         ${TEST_NAME}
         COMMAND
@@ -81,8 +88,7 @@ if(BUILD_TESTING)
     set(TEST_NAME test_speckle_filter)
     set(RESULT_FILENAME ${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${TEST_NAME}.gtest.xml)
     ament_add_gtest_executable(${TEST_NAME} test/${TEST_NAME}.cpp)
-    ament_target_dependencies(${TEST_NAME} angles)
-    target_link_libraries(${TEST_NAME} laser_scan_filters)
+    target_link_libraries(${TEST_NAME} angles::angles laser_scan_filters)
     ament_add_test(
         ${TEST_NAME}
         COMMAND
@@ -95,8 +101,11 @@ if(BUILD_TESTING)
     set(TEST_NAME test_scan_shadows_filter)
     set(RESULT_FILENAME ${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${TEST_NAME}.gtest.xml)
     ament_add_gtest_executable(${TEST_NAME} test/${TEST_NAME}.cpp)
-    ament_target_dependencies(${TEST_NAME} filters rclcpp sensor_msgs)
-    target_link_libraries(${TEST_NAME} laser_scan_filters)
+    target_link_libraries(${TEST_NAME}
+        laser_scan_filters
+        rclcpp::rclcpp
+        ${sensor_msgs_TARGETS}
+    )
     ament_add_test(
         ${TEST_NAME}
         COMMAND

--- a/include/laser_filters/speckle_filter.h
+++ b/include/laser_filters/speckle_filter.h
@@ -224,7 +224,7 @@ public:
     /*Check if range size is big enough to use the filter window */
     if (output_scan.ranges.size() <= filter_window + 1)
     {
-      RCLCPP_ERROR(logging_interface_->get_logger(), "Scan ranges size is too small for set window: size = %i, window = %i", output_scan.ranges.size(), filter_window);
+      RCLCPP_ERROR(logging_interface_->get_logger(), "Scan ranges size is too small for set window: size = %li, window = %i", output_scan.ranges.size(), filter_window);
       return false;
     }
 

--- a/src/generic_laser_filter_node.cpp
+++ b/src/generic_laser_filter_node.cpp
@@ -1,10 +1,10 @@
 /*
  * Copyright (c) 2008, Willow Garage, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- * 
+ *
  *     * Redistributions of source code must retain the above copyright
  *       notice, this list of conditions and the following disclaimer.
  *     * Redistributions in binary form must reproduce the above copyright
@@ -13,7 +13,7 @@
  *     * Neither the name of the Willow Garage, Inc. nor the names of its
  *       contributors may be used to endorse or promote products derived from
  *       this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -39,7 +39,7 @@ typedef tf2_ros::TransformListener TransformListener;
 
 #define NO_TIMER
 
-#include "message_filters/subscriber.h"
+#include "message_filters/subscriber.hpp"
 #include "filters/filter_chain.hpp"
 
 using namespace std::chrono_literals;
@@ -77,7 +77,7 @@ public:
       : nh_(nh),
         tf_(buffer_),
         buffer_(nh_->get_clock()),
-        scan_sub_(nh_, "scan", rmw_qos_profile_sensor_data),
+        scan_sub_(nh_, "scan", rclcpp::SensorDataQoS()),
         tf_filter_(scan_sub_, buffer_, "base_link", 50, nh_),
         filter_chain_("sensor_msgs::msg::LaserScan")
   {
@@ -108,7 +108,7 @@ public:
   {
     // Run the filter chain
     filter_chain_.update (*msg_in, msg_);
-    
+
     // Publish the output
     output_pub_->publish(msg_);
   }

--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -98,18 +98,18 @@ ScanToCloudFilterChain::ScanToCloudFilterChain(
         if (s.current_count == 0) {
           scan_sub_.unsubscribe();
         } else if (!scan_sub_.getSubscriber()) {
-          scan_sub_.subscribe(this, "scan", rmw_qos_profile_sensor_data);
+          scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
         }
       };
     cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
       "cloud_filtered", 10, pub_options);
   } else {
     cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("cloud_filtered", 10);
-    scan_sub_.subscribe(this, "scan", rmw_qos_profile_sensor_data);
+    scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
   }
   #else
   cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("cloud_filtered", 10);
-  scan_sub_.subscribe(this, "scan", rmw_qos_profile_sensor_data);
+  scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
   #endif
 
   cloud_filter_chain_.configure(

--- a/src/scan_to_cloud_filter_chain.hpp
+++ b/src/scan_to_cloud_filter_chain.hpp
@@ -45,7 +45,7 @@
 #include "tf2_ros/message_filter.h"
 #include "tf2_ros/create_timer_ros.h"
 
-#include "message_filters/subscriber.h"
+#include "message_filters/subscriber.hpp"
 
 // Laser projection
 #include <laser_geometry/laser_geometry.hpp>

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -44,7 +44,7 @@ ScanToScanFilterChain::ScanToScanFilterChain(
 {
   // Heartbeat diagnostics
   diagnostic_updater_.add(heartbeat_diagnostics_);
-  
+
   // Configure filter chain
   filter_chain_.configure(
     "",
@@ -98,18 +98,18 @@ ScanToScanFilterChain::ScanToScanFilterChain(
         if (s.current_count == 0) {
           scan_sub_.unsubscribe();
         } else if (!scan_sub_.getSubscriber()) {
-          scan_sub_.subscribe(this, "scan", rmw_qos_profile_sensor_data);
+          scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
         }
       };
     output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(
       "scan_filtered", 1000, pub_options);
   } else {
     output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan_filtered", 1000);
-    scan_sub_.subscribe(this, "scan", rmw_qos_profile_sensor_data);
+    scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
   }
   #else
   output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan_filtered", 1000);
-  scan_sub_.subscribe(this, "scan", rmw_qos_profile_sensor_data);
+  scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
   #endif
 }
 

--- a/src/scan_to_scan_filter_chain.hpp
+++ b/src/scan_to_scan_filter_chain.hpp
@@ -37,7 +37,7 @@
 #include <tf2_ros/transform_listener.h>
 #include "tf2_ros/message_filter.h"
 
-#include "message_filters/subscriber.h"
+#include "message_filters/subscriber.hpp"
 
 #include "filters/filter_chain.hpp"
 


### PR DESCRIPTION
`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.

Debs build is broken https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__laser_filters__ubuntu_noble_amd64__binary/

I also removed some other deprecations.

we should create a different branch for older versions.