### PR TITLE
Remove rolling from ros2 branch CI

### DIFF
--- a/.github/workflows/ros2_ci.yml
+++ b/.github/workflows/ros2_ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rosdistro: [humble, jazzy, rolling]
+        rosdistro: [humble, jazzy]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Rolling is now released from the "rolling" branch.