### PR TITLE
Remove kilted from rolling CI

### DIFF
--- a/.github/workflows/ros2_ci.yml
+++ b/.github/workflows/ros2_ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        rosdistro: [kilted, rolling]
+        rosdistro: [rolling]
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Kilted is now released from the "kilted" branch.