### PR TITLE
Set hardware id

### DIFF
--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -44,7 +44,8 @@ ScanToScanFilterChain::ScanToScanFilterChain(
 {
   // Heartbeat diagnostics
   diagnostic_updater_.add(heartbeat_diagnostics_);
-  
+  diagnostic_updater_.setHardwareID("laser_filters");
+
   // Configure filter chain
   filter_chain_.configure(
     "",


### PR DESCRIPTION
I specified the hardware ID so that the warning no longer appears.

- fix #233 