### PR TITLE
Expose depth_publisher param

### DIFF
--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -60,7 +60,7 @@ ScanToScanFilterChain::ScanToScanFilterChain(
   #endif
   this->declare_parameter("tf_message_filter_target_frame", "", read_only_desc);
   this->declare_parameter("tf_message_filter_tolerance", 0.03, read_only_desc);
-  this->declare_parameter("depth_publisher", 1000);
+  this->declare_parameter("scan_filtered_history_depth", 1000);
 
   // Get parameters
   #ifdef RCLCPP_SUPPORTS_MATCHED_CALLBACKS
@@ -68,7 +68,7 @@ ScanToScanFilterChain::ScanToScanFilterChain(
   #endif
   this->get_parameter("tf_message_filter_target_frame", tf_message_filter_target_frame_);
   this->get_parameter("tf_message_filter_tolerance", tf_filter_tolerance_);
-  this->get_parameter("depth_publisher", depth_publisher_);
+  this->get_parameter("scan_filtered_history_depth", scan_filtered_history_depth_);
 
   if (!tf_message_filter_target_frame_.empty()) {
     tf_.reset(new tf2_ros::TransformListener(buffer_));
@@ -105,15 +105,15 @@ ScanToScanFilterChain::ScanToScanFilterChain(
         }
       };
     output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(
-      "scan_filtered", depth_publisher_, pub_options);
+      "scan_filtered", scan_filtered_history_depth_, pub_options);
   } else {
     output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(
-      "scan_filtered", depth_publisher_);
+      "scan_filtered", scan_filtered_history_depth_);
     scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
   }
   #else
   output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(
-    "scan_filtered", depth_publisher_);
+    "scan_filtered", scan_filtered_history_depth_);
   scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
   #endif
 }

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -60,6 +60,7 @@ ScanToScanFilterChain::ScanToScanFilterChain(
   #endif
   this->declare_parameter("tf_message_filter_target_frame", "", read_only_desc);
   this->declare_parameter("tf_message_filter_tolerance", 0.03, read_only_desc);
+  this->declare_parameter("depth_publisher", 1000);
 
   // Get parameters
   #ifdef RCLCPP_SUPPORTS_MATCHED_CALLBACKS
@@ -67,6 +68,7 @@ ScanToScanFilterChain::ScanToScanFilterChain(
   #endif
   this->get_parameter("tf_message_filter_target_frame", tf_message_filter_target_frame_);
   this->get_parameter("tf_message_filter_tolerance", tf_filter_tolerance_);
+  this->get_parameter("depth_publisher", depth_publisher_);
 
   if (!tf_message_filter_target_frame_.empty()) {
     tf_.reset(new tf2_ros::TransformListener(buffer_));
@@ -103,13 +105,15 @@ ScanToScanFilterChain::ScanToScanFilterChain(
         }
       };
     output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(
-      "scan_filtered", 1000, pub_options);
+      "scan_filtered", depth_publisher_, pub_options);
   } else {
-    output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan_filtered", 1000);
+    output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(
+      "scan_filtered", depth_publisher_);
     scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
   }
   #else
-  output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>("scan_filtered", 1000);
+  output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(
+    "scan_filtered", depth_publisher_);
   scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
   #endif
 }

--- a/src/scan_to_scan_filter_chain.hpp
+++ b/src/scan_to_scan_filter_chain.hpp
@@ -65,6 +65,7 @@ protected:
   #endif
   std::string tf_message_filter_target_frame_;
   double tf_filter_tolerance_;
+  int depth_publisher_;
 
   // Diagnostic updater
   diagnostic_updater::Heartbeat heartbeat_diagnostics_;

--- a/src/scan_to_scan_filter_chain.hpp
+++ b/src/scan_to_scan_filter_chain.hpp
@@ -65,7 +65,7 @@ protected:
   #endif
   std::string tf_message_filter_target_frame_;
   double tf_filter_tolerance_;
-  int depth_publisher_;
+  int scan_filtered_history_depth_;
 
   // Diagnostic updater
   diagnostic_updater::Heartbeat heartbeat_diagnostics_;


### PR DESCRIPTION
Adds param `depth_publisher`, without changing the current default of 1000, to allow changing the depth of the `scan_to_scan_filter_chain` output topic.
For https://github.com/ros-perception/laser_filters/issues/249