### PR TITLE
Enable qos overriding for the output topic

### DIFF
--- a/src/generic_laser_filter_node.cpp
+++ b/src/generic_laser_filter_node.cpp
@@ -89,7 +89,9 @@ public:
     tf_filter_.setTolerance(0.03s);
 
     // Advertise output
-    output_pub_ = nh_->create_publisher<sensor_msgs::msg::LaserScan>("output", 1000);
+    rclcpp::PublisherOptions pub_options;
+    pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
+    output_pub_ = nh_->create_publisher<sensor_msgs::msg::LaserScan>("output", 1000, pub_options);
 
     std::function<void(const sensor_msgs::msg::LaserScan::SharedPtr)> standard_callback =
       std::bind(&GenericLaserScanFilterNode::foo, this, std::placeholders::_1);

--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -88,9 +88,10 @@ ScanToCloudFilterChain::ScanToCloudFilterChain(
     this->get_node_timers_interface());
   buffer_.setCreateTimerInterface(timer_interface);
 
+  rclcpp::PublisherOptions pub_options;
+  pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
   #ifdef RCLCPP_SUPPORTS_MATCHED_CALLBACKS
   if (lazy_subscription_) {
-    rclcpp::PublisherOptions pub_options;
     pub_options.event_callbacks.matched_callback =
       [this](rclcpp::MatchedInfo & s)
       {
@@ -103,11 +104,11 @@ ScanToCloudFilterChain::ScanToCloudFilterChain(
     cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
       "cloud_filtered", 10, pub_options);
   } else {
-    cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("cloud_filtered", 10);
+    cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("cloud_filtered", 10, pub_options);
     scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
   }
   #else
-  cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("cloud_filtered", 10);
+  cloud_pub_ = this->create_publisher<sensor_msgs::msg::PointCloud2>("cloud_filtered", 10, pub_options);
   scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
   #endif
 

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -92,9 +92,10 @@ ScanToScanFilterChain::ScanToScanFilterChain(
         std::placeholders::_1));
   }
 
+  rclcpp::PublisherOptions pub_options;
+  pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
   #ifdef RCLCPP_SUPPORTS_MATCHED_CALLBACKS
   if (lazy_subscription_) {
-    rclcpp::PublisherOptions pub_options;
     pub_options.event_callbacks.matched_callback =
       [this](rclcpp::MatchedInfo & s)
       {
@@ -108,12 +109,12 @@ ScanToScanFilterChain::ScanToScanFilterChain(
       "scan_filtered", scan_filtered_history_depth_, pub_options);
   } else {
     output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(
-      "scan_filtered", scan_filtered_history_depth_);
+      "scan_filtered", scan_filtered_history_depth_, pub_options);
     scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
   }
   #else
   output_pub_ = this->create_publisher<sensor_msgs::msg::LaserScan>(
-    "scan_filtered", scan_filtered_history_depth_);
+    "scan_filtered", scan_filtered_history_depth_, pub_options);
   scan_sub_.subscribe(this, "scan", rclcpp::SensorDataQoS());
   #endif
 }


### PR DESCRIPTION
Enable QoS overriding for the publisher.

This allows to configure the publisher qos via the `qos_overrides./scan_filtered.publisher.*` parameters.
This makes the `scan_filtered_history_depth` parameter a bit redundant.

Reason: I am using rmw_zenoh, and in Zenoh the publisher decides of the final reliability. I want my scans to be in best_effort.