### PR TITLE
Configure the tf buffer timer creator in scan_to_scan_filter_chain

### DIFF
--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -30,6 +30,8 @@
 
 #include "scan_to_scan_filter_chain.hpp"
 
+#include <tf2_ros/create_timer_ros.hpp>
+
 
 // Constructor
 ScanToScanFilterChain::ScanToScanFilterChain(
@@ -71,6 +73,10 @@ ScanToScanFilterChain::ScanToScanFilterChain(
   this->get_parameter("scan_filtered_history_depth", scan_filtered_history_depth_);
 
   if (!tf_message_filter_target_frame_.empty()) {
+    auto timer_interface = std::make_shared<tf2_ros::CreateTimerROS>(
+      get_node_base_interface(),
+      get_node_timers_interface());
+    buffer_.setCreateTimerInterface(std::move(timer_interface));
     tf_.reset(new tf2_ros::TransformListener(buffer_));
     tf_filter_.reset(
       new tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>(


### PR DESCRIPTION
Configure the tf buffer by calling setCreateTimerInterface so the message filter can call waitForTransform.

How should I go about making a backport for jazzy?

Closes #256