### PR TITLE
Re-use the main filter node for the tf2_ros::MessageFilter TransformListener

### DIFF
--- a/src/scan_to_cloud_filter_chain.cpp
+++ b/src/scan_to_cloud_filter_chain.cpp
@@ -45,7 +45,7 @@ ScanToCloudFilterChain::ScanToCloudFilterChain(
   diagnostic_updater_(this),
   laser_max_range_(DBL_MAX),
   buffer_(this->get_clock()),
-  tf_(buffer_),
+  tf_(buffer_, this),
   filter_(scan_sub_, buffer_, "", 50, *this),
   cloud_filter_chain_("sensor_msgs::msg::PointCloud2"),
   scan_filter_chain_("sensor_msgs::msg::LaserScan")

--- a/src/scan_to_scan_filter_chain.cpp
+++ b/src/scan_to_scan_filter_chain.cpp
@@ -71,7 +71,7 @@ ScanToScanFilterChain::ScanToScanFilterChain(
   this->get_parameter("scan_filtered_history_depth", scan_filtered_history_depth_);
 
   if (!tf_message_filter_target_frame_.empty()) {
-    tf_.reset(new tf2_ros::TransformListener(buffer_));
+    tf_.reset(new tf2_ros::TransformListener(buffer_, this));
     tf_filter_.reset(
       new tf2_ros::MessageFilter<sensor_msgs::msg::LaserScan>(
         scan_sub_, buffer_, "",


### PR DESCRIPTION
The TransformListener [recommends to re-use a node](https://github.com/ros2/geometry2/blob/51cc6451e49385ff03a324d23641910972764414/tf2_ros/include/tf2_ros/transform_listener.hpp#L103-L105) when possible.

This avoids spawning a new node uselessly.

By the way, I think we could also pass spin_thread=false in this specific use case, since we don't use the timeout mechanism.