### PR TITLE
Add Windows export settings for laser_filters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,11 @@ ament_auto_add_library(laser_filter_chains SHARED
                          src/scan_to_cloud_filter_chain.cpp
                          src/scan_to_scan_filter_chain.cpp)
 
+if(WIN32)
+  set_target_properties(laser_scan_filters PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  set_target_properties(laser_filter_chains PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 # The rclcpp_components_register_node macro registers an rclcpp component for the node with
 # the ament resource index AND creates a templated executable that spins the given node.
 

--- a/include/laser_filters/binning_filter.h
+++ b/include/laser_filters/binning_filter.h
@@ -51,7 +51,7 @@ class LaserScanBinningFilter : public filters::FilterBase<sensor_msgs::msg::Lase
 {
 public:
 
-  uint num_bins_;
+  unsigned int num_bins_;
 
   bool configure()
   {


### PR DESCRIPTION
This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-laser-filters.win.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: the laser_filters shared libraries need exported symbols on Windows, and the scan binning filter should avoid the non-standard uint typedef for better compiler portability.
