### PR TITLE
Give box/footprint/polygon filters unique private node names

### DIFF
--- a/include/laser_filters/box_filter.h
+++ b/include/laser_filters/box_filter.h
@@ -73,7 +73,7 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserSca
     {
       node_ = getUniqueNode("box_filter", this);
       buffer_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
-      tf_ = std::make_shared<tf2_ros::TransformListener>(*buffer_);
+      tf_ = std::make_shared<tf2_ros::TransformListener>(*buffer_, node_);
 
       up_and_running_ = true;
       double min_x, min_y, min_z, max_x, max_y, max_z;

--- a/include/laser_filters/box_filter.h
+++ b/include/laser_filters/box_filter.h
@@ -56,20 +56,25 @@
 typedef tf2::Vector3 Point;
 
 #include <laser_geometry/laser_geometry.hpp>
-#include <rclcpp_lifecycle/lifecycle_node.hpp>
+
+#include "laser_filters/util.h"
 
 namespace laser_filters
 {
 /**
  * @brief This is a filter that removes points in a laser scan inside of a cartesian box.
  */
-class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan>, public rclcpp_lifecycle::LifecycleNode
+class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan>
 {
   public:
-    LaserScanBoxFilter() : rclcpp_lifecycle::LifecycleNode("laser_scan_box_filter"), buffer_(get_clock()), tf_(buffer_){};
+    LaserScanBoxFilter() {};
 
     bool configure()
     {
+      node_ = getUniqueNode("box_filter", this);
+      buffer_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
+      tf_ = std::make_shared<tf2_ros::TransformListener>(*buffer_);
+
       up_and_running_ = true;
       double min_x, min_y, min_z, max_x, max_y, max_z;
       bool box_frame_set = getParam("box_frame", box_frame_);
@@ -93,31 +98,31 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserSca
 
       if (!box_frame_set)
       {
-        RCLCPP_ERROR(get_logger(), "box_frame is not set!");
+        RCLCPP_ERROR(node_->get_logger(), "box_frame is not set!");
       }
       if (!x_max_set)
       {
-        RCLCPP_ERROR(get_logger(), "max_x is not set!");
+        RCLCPP_ERROR(node_->get_logger(), "max_x is not set!");
       }
       if (!y_max_set)
       {
-        RCLCPP_ERROR(get_logger(), "max_y is not set!");
+        RCLCPP_ERROR(node_->get_logger(), "max_y is not set!");
       }
       if (!z_max_set)
       {
-        RCLCPP_ERROR(get_logger(), "max_z is not set!");
+        RCLCPP_ERROR(node_->get_logger(), "max_z is not set!");
       }
       if (!x_min_set)
       {
-        RCLCPP_ERROR(get_logger(), "min_x is not set!");
+        RCLCPP_ERROR(node_->get_logger(), "min_x is not set!");
       }
       if (!y_min_set)
       {
-        RCLCPP_ERROR(get_logger(), "min_y is not set!");
+        RCLCPP_ERROR(node_->get_logger(), "min_y is not set!");
       }
       if (!z_min_set)
       {
-        RCLCPP_ERROR(get_logger(), "min_z is not set!");
+        RCLCPP_ERROR(node_->get_logger(), "min_z is not set!");
       }
 
       return box_frame_set && x_max_set && y_max_set && z_max_set &&
@@ -134,7 +139,7 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserSca
 
       std::string error_msg;
 
-      bool success = buffer_.canTransform(
+      bool success = buffer_->canTransform(
           box_frame_,
           input_scan.header.frame_id,
           rclcpp::Time(input_scan.header.stamp) + std::chrono::duration<double>(input_scan.ranges.size() * input_scan.time_increment),
@@ -142,25 +147,25 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserSca
           &error_msg);
       if (!success)
       {
-        RCLCPP_WARN(get_logger(), "Could not get transform, irgnoring laser scan! %s", error_msg.c_str());
+        RCLCPP_WARN(node_->get_logger(), "Could not get transform, irgnoring laser scan! %s", error_msg.c_str());
         return false;
       }
 
       rclcpp::Clock steady_clock(RCL_STEADY_TIME);
       try
       {
-        projector_.transformLaserScanToPointCloud(box_frame_, input_scan, laser_cloud, buffer_);
+        projector_.transformLaserScanToPointCloud(box_frame_, input_scan, laser_cloud, *buffer_);
       }
       catch (tf2::TransformException &ex)
       {
         if (up_and_running_)
         {
-          RCLCPP_WARN_THROTTLE(get_logger(), steady_clock, 1, "Dropping Scan: Tansform unavailable %s", ex.what());
+          RCLCPP_WARN_THROTTLE(node_->get_logger(), steady_clock, 1, "Dropping Scan: Tansform unavailable %s", ex.what());
           return true;
         }
         else
         {
-          RCLCPP_INFO_THROTTLE(get_logger(), steady_clock, .3, "Ignoring Scan: Waiting for TF");
+          RCLCPP_INFO_THROTTLE(node_->get_logger(), steady_clock, .3, "Ignoring Scan: Waiting for TF");
         }
         return false;
       }
@@ -176,7 +181,7 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserSca
         !(iter_y != iter_y.end()) ||
         !(iter_z != iter_z.end()))
       {
-        RCLCPP_INFO_THROTTLE(get_logger(), steady_clock, .3, "x, y, z and index fields are required, skipping scan");
+        RCLCPP_INFO_THROTTLE(node_->get_logger(), steady_clock, .3, "x, y, z and index fields are required, skipping scan");
       }
 
     for (;
@@ -209,9 +214,13 @@ class LaserScanBoxFilter : public filters::FilterBase<sensor_msgs::msg::LaserSca
     std::string box_frame_;
     laser_geometry::LaserProjection projector_;
 
+    // node private to this filter, so its name stays unique even under a
+    // process-wide "-r __node:=<name>" remap (see laser_filters/util.h)
+    rclcpp::Node::SharedPtr node_;
+
     // tf listener to transform scans into the box_frame
-    tf2_ros::Buffer buffer_;
-    tf2_ros::TransformListener tf_;
+    std::shared_ptr<tf2_ros::Buffer> buffer_;
+    std::shared_ptr<tf2_ros::TransformListener> tf_;
 
     // parameter to decide if points in box or points outside of box are removed
     bool remove_box_points_ = true;

--- a/include/laser_filters/footprint_filter.h
+++ b/include/laser_filters/footprint_filter.h
@@ -50,25 +50,27 @@ This is useful for ground plane extraction
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp> // PointCloud2ConstIterator
 #include <geometry_msgs/msg/point32.hpp>
-#include <rclcpp_lifecycle/lifecycle_node.hpp>
 
 #include "laser_geometry/laser_geometry.hpp"
+#include "laser_filters/util.h"
 
 namespace laser_filters
 {
 
-class LaserScanFootprintFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan>, public rclcpp_lifecycle::LifecycleNode
+class LaserScanFootprintFilter : public filters::FilterBase<sensor_msgs::msg::LaserScan>
 {
 public:
-  LaserScanFootprintFilter()
-      : rclcpp_lifecycle::LifecycleNode("laser_scan_footprint_filter"),
-        buffer_(get_clock()), tf_(buffer_), up_and_running_(false) {}
+  LaserScanFootprintFilter() : up_and_running_(false) {}
 
   bool configure()
   {
+    node_ = getUniqueNode("footprint_filter", this);
+    buffer_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
+    tf_ = std::make_shared<tf2_ros::TransformListener>(*buffer_);
+
     if(!getParam("inscribed_radius", inscribed_radius_))
     {
-      RCLCPP_ERROR(get_logger(), "LaserScanFootprintFilter needs inscribed_radius to be set");
+      RCLCPP_ERROR(node_->get_logger(), "LaserScanFootprintFilter needs inscribed_radius to be set");
       return false;
     }
     return true;
@@ -84,18 +86,18 @@ public:
     sensor_msgs::msg::PointCloud2 laser_cloud;
 
     try{
-      projector_.transformLaserScanToPointCloud("base_link", input_scan, laser_cloud, buffer_);
+      projector_.transformLaserScanToPointCloud("base_link", input_scan, laser_cloud, *buffer_);
     }
     catch (tf2::TransformException &ex)
     {
       rclcpp::Clock steady_clock(RCL_STEADY_TIME);
       if (up_and_running_)
       {
-        RCLCPP_WARN_THROTTLE(get_logger(), steady_clock, 1, "Dropping Scan: Transform unavailable %s", ex.what());
+        RCLCPP_WARN_THROTTLE(node_->get_logger(), steady_clock, 1, "Dropping Scan: Transform unavailable %s", ex.what());
       }
       else
       {
-        RCLCPP_INFO_THROTTLE(get_logger(), steady_clock, .3, "Ignoring Scan: Waiting for TF");
+        RCLCPP_INFO_THROTTLE(node_->get_logger(), steady_clock, .3, "Ignoring Scan: Waiting for TF");
       }
       return false;
     }
@@ -107,7 +109,7 @@ public:
 
     if (!(iter_i != iter_i.end()))
     {
-      RCLCPP_ERROR(get_logger(), "We need an index channel to be able to filter out the footprint");
+      RCLCPP_ERROR(node_->get_logger(), "We need an index channel to be able to filter out the footprint");
       return false;
     }
 
@@ -142,8 +144,12 @@ public:
   }
 
 private:
-  tf2_ros::Buffer buffer_;
-  tf2_ros::TransformListener tf_;
+  // node private to this filter, so its name stays unique even under a
+  // process-wide "-r __node:=<name>" remap (see laser_filters/util.h)
+  rclcpp::Node::SharedPtr node_;
+
+  std::shared_ptr<tf2_ros::Buffer> buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_;
   laser_geometry::LaserProjection projector_;
   double inscribed_radius_;
   bool up_and_running_;

--- a/include/laser_filters/footprint_filter.h
+++ b/include/laser_filters/footprint_filter.h
@@ -66,7 +66,7 @@ public:
   {
     node_ = getUniqueNode("footprint_filter", this);
     buffer_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
-    tf_ = std::make_shared<tf2_ros::TransformListener>(*buffer_);
+    tf_ = std::make_shared<tf2_ros::TransformListener>(*buffer_, node_);
 
     if(!getParam("inscribed_radius", inscribed_radius_))
     {

--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -53,11 +53,13 @@
 #include <geometry_msgs/msg/polygon.hpp>
 #include <geometry_msgs/msg/polygon_stamped.hpp>
 
-#include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/buffer.hpp>
+#include <tf2_ros/transform_listener.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rcl_interfaces/msg/set_parameters_result.hpp>
+
+#include "laser_filters/util.h"
 
 
 typedef tf2::Vector3 Point;
@@ -222,15 +224,19 @@ namespace laser_filters
 /**
  * @brief This is a filter that removes points in a laser scan inside of a polygon.
  */
-class LaserScanPolygonFilterBase : public filters::FilterBase<sensor_msgs::msg::LaserScan>, public rclcpp_lifecycle::LifecycleNode {
+class LaserScanPolygonFilterBase : public filters::FilterBase<sensor_msgs::msg::LaserScan> {
 public:
 
-  LaserScanPolygonFilterBase() : rclcpp_lifecycle::LifecycleNode("laser_scan_polygon_filter"), buffer_(get_clock()), tf_(buffer_){};
+  LaserScanPolygonFilterBase() {};
 
   virtual bool configure()
   {
+    node_ = getUniqueNode("polygon_filter", this);
+    buffer_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
+    tf_ = std::make_shared<tf2_ros::TransformListener>(*buffer_);
+
     // dynamic reconfigure parameters callback:
-    on_set_parameters_callback_handle_ = add_on_set_parameters_callback(
+    on_set_parameters_callback_handle_ = node_->add_on_set_parameters_callback(
               std::bind(&LaserScanPolygonFilterBase::reconfigureCB, this, std::placeholders::_1));
 
     std::string polygon_string;
@@ -258,7 +264,7 @@ public:
     polygon_ = makePolygonFromString(polygon_string, polygon_);
     padPolygon(polygon_, polygon_padding_);
 
-    polygon_pub_ = create_publisher<geometry_msgs::msg::PolygonStamped>("polygon", rclcpp::QoS(1).transient_local().keep_last(1));
+    polygon_pub_ = node_->create_publisher<geometry_msgs::msg::PolygonStamped>("polygon", rclcpp::QoS(1).transient_local().keep_last(1));
     is_polygon_published_ = false;
 
     return true;
@@ -290,9 +296,13 @@ protected:
   bool is_polygon_published_ = false;
 
 
+  // node private to this filter, so its name stays unique even under a
+  // process-wide "-r __node:=<name>" remap (see laser_filters/util.h)
+  rclcpp::Node::SharedPtr node_;
+
   // tf listener to transform scans into the right frame
-  tf2_ros::Buffer buffer_;
-  tf2_ros::TransformListener tf_;
+  std::shared_ptr<tf2_ros::Buffer> buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_;
 
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr on_set_parameters_callback_handle_;
   virtual rcl_interfaces::msg::SetParametersResult reconfigureCB(std::vector<rclcpp::Parameter> parameters)
@@ -350,7 +360,7 @@ protected:
     {
       geometry_msgs::msg::PolygonStamped polygon_stamped;
       polygon_stamped.header.frame_id = polygon_frame_;
-      polygon_stamped.header.stamp = get_clock()->now();
+      polygon_stamped.header.stamp = node_->get_clock()->now();
       polygon_stamped.polygon = polygon_;
       polygon_pub_->publish(polygon_stamped);
       is_polygon_published_ = true;
@@ -363,7 +373,7 @@ public:
   bool configure() override
   {
     bool result = LaserScanPolygonFilterBase::configure();
-    footprint_sub_ = create_subscription<geometry_msgs::msg::Polygon>(footprint_topic_, 1, std::bind(&LaserScanPolygonFilterBase::footprintCB, this, std::placeholders::_1));
+    footprint_sub_ = node_->create_subscription<geometry_msgs::msg::Polygon>(footprint_topic_, 1, std::bind(&LaserScanPolygonFilterBase::footprintCB, this, std::placeholders::_1));
     return result;
   }
 
@@ -381,7 +391,7 @@ public:
 
     std::string error_msg;
 
-    bool success = buffer_.canTransform(
+    bool success = buffer_->canTransform(
       polygon_frame_,
       input_scan.header.frame_id,
       rclcpp::Time(input_scan.header.stamp) + std::chrono::duration<double>(input_scan.ranges.size() * input_scan.time_increment),
@@ -394,10 +404,10 @@ public:
     }
 
     try{
-      projector_.transformLaserScanToPointCloud(polygon_frame_, input_scan, laser_cloud, buffer_);
+      projector_.transformLaserScanToPointCloud(polygon_frame_, input_scan, laser_cloud, *buffer_);
     }
     catch(tf2::TransformException& ex){
-      RCLCPP_INFO_THROTTLE(logging_interface_->get_logger(), *get_clock(), 300, "Ignoring Scan: Waiting for TF");
+      RCLCPP_INFO_THROTTLE(logging_interface_->get_logger(), *node_->get_clock(), 300, "Ignoring Scan: Waiting for TF");
       return false;
     }
 
@@ -408,7 +418,7 @@ public:
 
     if (i_idx_c == -1 || x_idx_c == -1 || y_idx_c == -1 || z_idx_c == -1)
     {
-      RCLCPP_INFO_THROTTLE(logging_interface_->get_logger(), *get_clock(), 300, "x, y, z and index fields are required, skipping scan");
+      RCLCPP_INFO_THROTTLE(logging_interface_->get_logger(), *node_->get_clock(), 300, "x, y, z and index fields are required, skipping scan");
     }
 
     const int i_idx_offset = laser_cloud.fields[i_idx_c].offset;
@@ -481,7 +491,7 @@ public:
     {
       RCLCPP_INFO(logging_interface_->get_logger(), "Error: PolygonFilter transform_timeout not set, assuming 5. \n");
     }
-    footprint_sub_ = create_subscription<geometry_msgs::msg::Polygon>(footprint_topic_, 1, std::bind(&StaticLaserScanPolygonFilter::footprintCB, this, std::placeholders::_1));
+    footprint_sub_ = node_->create_subscription<geometry_msgs::msg::Polygon>(footprint_topic_, 1, std::bind(&StaticLaserScanPolygonFilter::footprintCB, this, std::placeholders::_1));
     return result;
   }
 
@@ -538,7 +548,7 @@ protected:
     geometry_msgs::msg::TransformStamped transform;
     try
     {
-      transform = buffer_.lookupTransform(input_scan_frame_id,
+      transform = buffer_->lookupTransform(input_scan_frame_id,
         polygon_frame_,
         tf2::TimePointZero,
         tf2::durationFromSec(transform_timeout_));
@@ -546,7 +556,7 @@ protected:
     catch(tf2::TransformException& ex)
     {
       RCLCPP_WARN_THROTTLE(logging_interface_->get_logger(),
-          *get_clock(), 1000,
+          *node_->get_clock(), 1000,
           "Could not get transform, ignoring laser scan! %s", ex.what());
           return false;
     }

--- a/include/laser_filters/polygon_filter.h
+++ b/include/laser_filters/polygon_filter.h
@@ -233,7 +233,7 @@ public:
   {
     node_ = getUniqueNode("polygon_filter", this);
     buffer_ = std::make_shared<tf2_ros::Buffer>(node_->get_clock());
-    tf_ = std::make_shared<tf2_ros::TransformListener>(*buffer_);
+    tf_ = std::make_shared<tf2_ros::TransformListener>(*buffer_, node_);
 
     // dynamic reconfigure parameters callback:
     on_set_parameters_callback_handle_ = node_->add_on_set_parameters_callback(

--- a/include/laser_filters/util.h
+++ b/include/laser_filters/util.h
@@ -1,0 +1,81 @@
+/*
+ *  Software License Agreement (BSD License)
+ *
+ *  Robot Operating System code by Eurotec B.V.
+ *  Copyright (c) 2020, Eurotec B.V.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   1. Redistributions of source code must retain the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer.
+ *
+ *   2. Redistributions in binary form must reproduce the above
+ *      copyright notice, this list of conditions and the following
+ *      disclaimer in the documentation and/or other materials provided
+ *      with the distribution.
+ *
+ *   3. Neither the name of the copyright holder nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ *  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ *  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ *  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ *  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ *  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ *  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+ *  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+ *  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ *  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ *
+ *  util.h
+ */
+
+#ifndef LASER_FILTERS__UTIL_H_
+#define LASER_FILTERS__UTIL_H_
+
+#include <rclcpp/rclcpp.hpp>
+#include <filters/filter_base.hpp>
+
+namespace laser_filters
+{
+  /**
+   * \brief Create a node that is unique to this filter.
+   *
+   * The node name is pinned via an explicit "-r __node:=<name>" argument local
+   * to this node, so it stays unique even when the parent process is launched
+   * with a bare "--ros-args -r __node:=<name>" rule, which otherwise renames
+   * every node created in the process to the same name and collides with it.
+   *
+   * \param filter_name The name of the filter, used to help make the node name unique.
+   * \param filter A pointer to the filter instance, used to help make the node name unique.
+   * \return A shared pointer to a node handle in the filter's private namespace
+   */
+  template <typename T>
+  rclcpp::Node::SharedPtr getUniqueNode(const std::string &filter_name, const filters::FilterBase<T> *filter)
+  {
+    char node_name[42];
+    snprintf(
+    node_name, sizeof(node_name), "%s_%zx",
+    filter_name.c_str(), reinterpret_cast<size_t>(filter)
+    );
+
+    rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared(
+      node_name,
+      rclcpp::NodeOptions().arguments(
+        {"--ros-args", "-r", "__node:=" + std::string(node_name)}));
+
+    return node;
+  }
+}
+
+#endif  // LASER_FILTERS__UTIL_H_


### PR DESCRIPTION
Fixes #214.

`box_filter`, `footprint_filter` and `polygon_filter` each spin up their own
internal node (for TF, and for polygon_filter also pub/sub/param callbacks).
That internal node used a fixed name, so a process-wide bare
`-r __node:=<name>` remap (e.g. `Node(name="laser_filter")` in a launch file)
silently renames it too, colliding with the parent filter-chain node and
producing `Publisher already registered for node name: 'laser_filter'`,
exactly as reported here and in https://github.com/ros-perception/laser_filters/issues/214#issuecomment-5291590730.

Each internal node now gets a name unique to the filter instance, pinned via
its own local `-r __node:=<name>` argument — that survives a process-wide
bare remap since node-specific rules take precedence over the wildcard one.

This follows the same approach @jonbinney used in #248 for box_filter/
polygon_filter (opened against #231), and extends it to footprint_filter,
which #248 doesn't cover but is affected by the same root cause.

Tested against the exact repro from the issue (scan_to_scan_filter_chain,
`--remap __node:=laser_filter`, box_filter via params file): the
"Publisher already registered" warning and the node-name collision are
gone, and the box filter's internal node keeps a unique name in
`ros2 node list`.